### PR TITLE
Update PricesYahoo

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -24,7 +24,7 @@ plugins = pydantic.mypy
 ;   pd.Timestamp attrs inc .hour, .minute, .value
 ;   pd.Timedelta attrs inc .resolution_string, .components
 ;   pd.Interval attrs inc .left, .right, .overlaps, .closed
-;   pd.Index attrs inc .is_non_overlapping_monotonic, .freq
+;   pd.Index attrs inc .is_non_overlapping_monotonic, .freq, tz_localize, tz
 ;   member of an Enum class
 ; call-arg
 ;   'Too many arguments for pd.Interval' (there aren't too many).

--- a/src/market_prices/errors.py
+++ b/src/market_prices/errors.py
@@ -618,6 +618,19 @@ class CalendarExpiredError(CalendarError):
         )
 
 
+class CalendarTooShortError(CalendarError):
+    """Calendar is too short to support intraday price history."""
+
+    def __init__(self, calendar: xcals.ExchangeCalendar, limit: pd.Timestamp):
+        self._msg = (
+            f"Calendar '{calendar.name}' is too short to support all available intraday"
+            f" price history. Calendar starts '{calendar.first_minute}' whilst earliest"
+            f" minute for which intraday price history is available is '{limit}'"
+            " (all calendars must be valid over at least the period for which intraday"
+            " price data is available)."
+        )
+
+
 class CompositeIndexConflict(MarketPricesError):
     """Some indices of composite trading index are misaligned."""
 
@@ -710,8 +723,8 @@ class PricesMissingWarning(PricesWarning):
         date_format = "%Y-%m-%d"
         sessions = sessions.format(date_format=date_format)
         self._msg = (
-            f"Intraday prices from {source} are missing for '{symbol}' at the"
-            f" base interval '{bi}' for the following sessions: {sessions}"
+            f"Prices from {source} are missing for '{symbol}' at the"
+            f" base interval '{bi}' for the following sessions: {sessions}."
         )
 
 
@@ -722,7 +735,7 @@ class DuplicateIndexWarning(PricesWarning):
         self._msg = (
             f"\nThe following indices for symbol '{symbol}' have"
             f" been removed as they were duplicated in data receieved from"
-            f" source:\n{duplicates}"
+            f" source:\n{duplicates}."
         )
 
 

--- a/tests/test_daterange.py
+++ b/tests/test_daterange.py
@@ -2554,6 +2554,7 @@ class TestGetterIntraday:
 
             drg = self.get_drg(cal, pp, strict=True, **drg_kwargs)
             start = end - (cal.day * pp["days"])
+            start = start if cal.is_trading_minute(start) else cal.previous_close(start)
             error_msg = re.escape(
                 f"Prices unavailable as start ({helpers.fts(start)}) is earlier than"
                 " the earliest minute for which price data is available. The earliest"


### PR DESCRIPTION
- Adds `_fill_reindexed_daily` to fill missing prices for daily data
and raise `PricesMissingWarning`.
- Adds `test__fill_reindexed_daily` to `test_yahoo.py`.
- Revises implementation of `yahoo_exchange_name` to raise error if
invalid symbol passed to constructor. Also adds `test_invalid_symbol`.
- Refactors part of `_set_daily_bi_limit` to new `_first_trade_dates`.
- Adds restriction to `PricesBase` that all calendars must cover period
over which intraday price data available. Also adds
`test_calendar_too_short_error` to test_base.py` and
`CalendarTooShortError` to `errors.py`.
- Revises `skip_if_fails_and_today_blacklisted` to query multiple
CompositeCalendars.

Also fixes:
- `TestGet.test_openend`
- `test_daterange_duration_days_end_oolb_minute`.