### PR TITLE
Update requirements, `__init__.__version__` and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,31 +13,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
-    
+
     - name: Build package
       run: python -m build
-    
+
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TEST_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-    
+
     # Verify can install from Test PyPI and import package
     - name: Verify from Test PyPI
       run: |
-        pip install --extra-index-url https://test.pypi.org/simple market_prices
+        echo "Will wait 10s" && sleep 10s
+        pip install --extra-index-url https://test.pypi.org/simple market_prices==${{ github.ref_name }}
         python -c 'import market_prices;print(market_prices.__version__)'
         pip uninstall -y market_prices
 
@@ -50,5 +51,6 @@ jobs:
     # Verify can install from PyPI and import package
     - name: Verify from PyPI
       run: |
-        pip install market_prices
+        echo "Will wait 10s" && sleep 10s
+        pip install market_prices==${{ github.ref_name }}
         python -c 'import market_prices;print(market_prices.__version__)'

--- a/docs/developers/releases.md
+++ b/docs/developers/releases.md
@@ -22,6 +22,7 @@ At the GitHub [releases page](https://github.com/maread99/market_prices/releases
 * The draft release notes should already be at the top of the page. Click the pen icon to edit the draft.
 * Tag the release. The draft will have suggested a tag for the release. If this tag doesn't reflect the intended version then either select the last commit's tag (if it was added) or create a new tag that reflects the version string (any new tag will be attached to last commit).
 * Make sure target is selected as 'refs/head/master'.
+* Name the release as the tag (e.g. "v0.9.2").
 * Revise the draft release notes as requried.
 * If the release includes new features, select the checkbox for 'Create a discussion for this release' (otherwise leave unchecked).
 * Click the 'Publish Release' button.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,17 +6,17 @@
 #
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 colorama==0.4.5
     # via tqdm
-exchange-calendars==4.0.2
+exchange-calendars==4.1.1
     # via market-prices (pyproject.toml)
 idna==3.3
     # via requests
 korean-lunar-calendar==0.2.1
     # via exchange-calendars
-lxml==4.9.0
+lxml==4.9.1
     # via yahooquery
 numpy==1.23.0
     # via
@@ -41,7 +41,7 @@ pytz==2022.1
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-requests==2.28.0
+requests==2.28.1
     # via requests-futures
 requests-futures==1.0.0
     # via yahooquery
@@ -51,7 +51,7 @@ toolz==0.11.2
     # via exchange-calendars
 tqdm==4.64.0
     # via yahooquery
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via pydantic
 urllib3==1.26.9
     # via requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,13 +12,15 @@ attrs==21.4.0
     # via
     #   hypothesis
     #   pytest
-black==22.3.0
+black==22.6.0
     # via market-prices (pyproject.toml)
+build==0.8.0
+    # via pip-tools
 certifi==2022.6.15
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -26,6 +28,7 @@ click==8.1.3
     #   pip-tools
 colorama==0.4.5
     # via
+    #   build
     #   click
     #   pylint
     #   pytest
@@ -36,7 +39,7 @@ distlib==0.3.4
     # via virtualenv
 exceptiongroup==1.0.0rc8
     # via hypothesis
-exchange-calendars==4.0.2
+exchange-calendars==4.1.1
     # via market-prices (pyproject.toml)
 filelock==3.7.1
     # via virtualenv
@@ -46,7 +49,7 @@ flake8==4.0.1
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.6.0
     # via market-prices (pyproject.toml)
-hypothesis==6.47.4
+hypothesis==6.49.1
     # via market-prices (pyproject.toml)
 identify==2.5.1
     # via pre-commit
@@ -60,7 +63,7 @@ korean-lunar-calendar==0.2.1
     # via exchange-calendars
 lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.9.0
+lxml==4.9.1
     # via yahooquery
 mccabe==0.6.1
     # via
@@ -73,9 +76,9 @@ mypy-extensions==0.4.3
     #   black
     #   market-prices (pyproject.toml)
     #   mypy
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-numexpr==2.8.1
+numexpr==2.8.3
     # via tables
 numpy==1.23.0
     # via
@@ -86,6 +89,7 @@ numpy==1.23.0
     #   tables
 packaging==21.3
     # via
+    #   build
     #   numexpr
     #   pytest
     #   tables
@@ -94,13 +98,13 @@ pandas==1.4.3
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==1.2.0.62
+pandas-stubs==1.4.3.220704
     # via market-prices (pyproject.toml)
 pathspec==0.9.0
     # via black
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via build
+pip-tools==6.8.0
     # via market-prices (pyproject.toml)
 platformdirs==2.5.2
     # via
@@ -121,7 +125,7 @@ pydocstyle==6.1.1
     # via flake8-docstrings
 pyflakes==2.4.0
     # via flake8
-pylint==2.14.3
+pylint==2.14.4
     # via market-prices (pyproject.toml)
 pyluach==2.0.0
     # via exchange-calendars
@@ -131,7 +135,7 @@ pytest==7.1.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.8.1
+pytest-mock==3.8.2
     # via market-prices (pyproject.toml)
 python-dateutil==2.8.2
     # via
@@ -144,7 +148,7 @@ pytz==2022.1
     #   pandas
 pyyaml==6.0
     # via pre-commit
-requests==2.28.0
+requests==2.28.1
     # via requests-futures
 requests-futures==1.0.0
     # via yahooquery
@@ -163,6 +167,7 @@ toml==0.10.2
 tomli==2.0.1
     # via
     #   black
+    #   build
     #   mypy
     #   pep517
     #   pylint
@@ -173,9 +178,9 @@ toolz==0.11.2
     # via exchange-calendars
 tqdm==4.64.0
     # via yahooquery
-types-pytz==2022.1.0
+types-pytz==2022.1.1
     # via market-prices (pyproject.toml)
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   black
@@ -184,7 +189,7 @@ typing-extensions==4.2.0
     #   pylint
 urllib3==1.26.9
     # via requests
-virtualenv==20.14.1
+virtualenv==20.15.1
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/src/market_prices/__init__.py
+++ b/src/market_prices/__init__.py
@@ -7,7 +7,26 @@ __all__ = [PricesYahoo, get_exchange_info]
 
 __copyright__ = "Copyright (c) 2022 Marcus Read"
 
+
+# Resolve version
+__version__ = None
+
 from importlib.metadata import version
 
-__version__ = version("market_prices")
+try:
+    # get version from installed package
+    __version__ = version("market_prices")
+except ImportError:
+    pass
+
+if __version__ is None:
+    try:
+        # if package not installed, get version as set when package built
+        from ._version import version
+    except Exception:
+        # If package not installed and not built, leave __version__ as None
+        pass
+    else:
+        __version__ = version
+
 del version


### PR DESCRIPTION
- Updates requirements files
- Updates resolving of `__init__.__version__`. If version not available from metadata of installed package then falls back on version as defined in `_version` when built.
- Updates release workflow to test by explicitly installing released version. Fixes #22.