### PR TITLE
Fixes for pandas upgrade from 1.4.3 to 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile pyproject.toml
 #
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -23,7 +23,7 @@ numpy==1.23.3
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==1.4.4
+pandas==1.5.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -36,7 +36,7 @@ python-dateutil==2.8.2
     # via
     #   exchange-calendars
     #   pandas
-pytz==2022.2.1
+pytz==2022.4
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ black==22.8.0
     # via market-prices (pyproject.toml)
 build==0.8.0
     # via pip-tools
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cfgv==3.3.1
     # via pre-commit
@@ -47,7 +47,7 @@ flake8==5.0.4
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.6.0
     # via market-prices (pyproject.toml)
-hypothesis==6.54.6
+hypothesis==6.56.0
     # via market-prices (pyproject.toml)
 identify==2.5.5
     # via pre-commit
@@ -67,7 +67,7 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==0.971
+mypy==0.981
     # via market-prices (pyproject.toml)
 mypy-extensions==0.4.3
     # via
@@ -91,12 +91,12 @@ packaging==21.3
     #   numexpr
     #   pytest
     #   tables
-pandas==1.4.4
+pandas==1.5.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==1.4.4.220912
+pandas-stubs==1.5.0.220926
     # via market-prices (pyproject.toml)
 pathspec==0.10.1
     # via black
@@ -123,7 +123,7 @@ pydocstyle==6.1.1
     # via flake8-docstrings
 pyflakes==2.5.0
     # via flake8
-pylint==2.15.2
+pylint==2.15.3
     # via market-prices (pyproject.toml)
 pyluach==2.0.1
     # via exchange-calendars
@@ -133,13 +133,13 @@ pytest==7.1.3
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.8.2
+pytest-mock==3.9.0
     # via market-prices (pyproject.toml)
 python-dateutil==2.8.2
     # via
     #   exchange-calendars
     #   pandas
-pytz==2022.2.1
+pytz==2022.4
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -168,7 +168,7 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via pylint
 toolz==0.12.0
     # via exchange-calendars

--- a/src/market_prices/daterange.py
+++ b/src/market_prices/daterange.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Callable
+from datetime import timedelta
 from typing import TYPE_CHECKING, Literal
 
 import exchange_calendars as xcals
@@ -399,7 +400,7 @@ class GetterDaily(_Getter):
                 # end will be reset to now after evaluating start.
                 one_day = helpers.ONE_DAY
                 end = self.final_interval.as_offset_ms.rollforward(end + one_day)
-                end -= one_day  # type: ignore[operator,assignment]
+                end -= one_day
 
             if self.pp["days"] > 0:
                 days = self.pp["days"]
@@ -431,10 +432,9 @@ class GetterDaily(_Getter):
                 )
                 if start is None:
                     assert end is not None
-                    # mypy ignored because Timestamp -/+ DateOffset is valid
-                    start = end - duration  # type: ignore[operator]
+                    start = end - duration
                 else:
-                    end = start + duration  # type: ignore[operator]
+                    end = start + duration
 
             start = self.get_start(start)
             end, end_accuracy = self.get_end(end)
@@ -459,12 +459,12 @@ class GetterDaily(_Getter):
             pp_start, pp_end = self.pp_start_end
             if pp_start is not None and pp_end is None and self._has_duration:
                 # align end
-                end = (end_ - excess) - helpers.ONE_DAY  # type: ignore[operator]
+                end = (end_ - excess) - helpers.ONE_DAY
                 end, end_accuracy = self.get_end(end)
             elif start is not None:  # align start
-                start = start_ = start + excess  # type: ignore[operator]
+                start = start_ = start + excess
             else:
-                start_ += excess  # type: ignore[operator]
+                start_ += excess
 
         self._check_period_covers_one_monthly_interval(start_, end)
 
@@ -479,7 +479,7 @@ class GetterDaily(_Getter):
 
         Period evaluated as `start` through `end`.
         """
-        assert isinstance(self.final_interval, (pd.Timedelta, intervals.TDInterval))
+        assert isinstance(self.final_interval, (timedelta, intervals.TDInterval))
         num_sessions = self.cal.sessions_distance(start, end)
         if pd.Timedelta(num_sessions, "D") < self.final_interval:
             cbdays = num_sessions * self.cal.day
@@ -539,10 +539,9 @@ class GetterDaily(_Getter):
                 )
                 if start is None:
                     assert end is not None
-                    # mypy ignored because Timestamp -/+ DateOffset is valid
-                    start = end - duration  # type: ignore[operator]
+                    start = end - duration
                 else:
-                    end = start + duration  # type: ignore[operator]
+                    end = start + duration
 
             start = self.get_start(start)
             end, end_accuracy = self.get_end(end)
@@ -1039,10 +1038,9 @@ class GetterIntraday(_Getter):
                     years=self.pp["years"],
                 )
                 if start is None:
-                    # mypy ignored because Timestamp -/+ DateOffset is valid
                     start = end - duration  # type: ignore[operator]
                 else:
-                    end = start + duration  # type: ignore[operator]
+                    end = start + duration
 
             start = self.get_start(start)
             end, end_accuracy = self.get_end(end)

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -108,8 +108,26 @@ class PricesBase(metaclass=abc.ABCMeta):
             provider (see 'Serving Price Data' section for notes on which
             intervals should be assigned as base intervals).
 
-            Note: On base class implemented as a type only. This type is
-            not enforced at runtime.
+            The value of enum members should be defined as a tuple of
+            values that would be passed to `timedelta` as positional
+            arguments to define the corresponding interval. For
+            convenience, common tuples are defined at
+            `intervals.TIMEDELTA_ARGS`.
+
+            Example BaseInterval definition:
+                BaseInterval = intervals._BaseInterval(
+                    "BaseInterval",
+                    dict(
+                        T1=intervals.TIMEDELTA_ARGS["T1"],  # 1 minute interval
+                        T2=intervals.TIMEDELTA_ARGS["T2"],  # 2 minute interval
+                        T5=intervals.TIMEDELTA_ARGS["T5"],  # 5 minute interval
+                        H1=intervals.TIMEDELTA_ARGS["H1"],  # 1 hour interval
+                        D1=intervals.TIMEDELTA_ARGS["D1"],  # 1 day interval
+                    ),
+                )
+
+            Note: On base class BaseInterval is implemented as a type only.
+            This type is not enforced at runtime.
 
         BASE_LIMITS :
         dict[BI, pd.Timestamp | pd.Timedelta | None]
@@ -2654,13 +2672,19 @@ class PricesBase(metaclass=abc.ABCMeta):
 
         - Parameters related to index -
 
-        interval : str | pd.Timedelta, default: inferred
+        interval : str | timedelta | pd.Timedelta, default: inferred
             Time interval to be represented by each price row.
 
             Pass as either:
                 pd.Timedelta: components as either:
                     - minutes and/or hours
                     - days
+
+                timedelta: defined from kwargs passed as either:
+                    - minutes and/or hours
+                    - days
+                    (or equivalent of, i.e seconds=120 is valid although
+                    seconds=121 is not.)
 
                 str: comprising:
                     value:
@@ -2675,14 +2699,17 @@ class PricesBase(metaclass=abc.ABCMeta):
                 thirty minutes:
                     "30min", "30T"
                     pd.Timedelta(30, "T"), pd.Timedelta(minutes=30)
+                    timedelta(minutes=30)
 
                 three hours:
                     "3h", "3H"
                     pd.Timedelta(3, "H"), pd.Timedelta(hours=3)
+                    timedelta(hours=3)
 
                 one day:
                     "1d", "1D"
                     pd.Timedelta(1, "D"), pd.Timedelta(days=1)
+                    timedelta(days=1), timedelta(1)
 
                 two months:
                     "2m", "2M"
@@ -2694,6 +2721,8 @@ class PricesBase(metaclass=abc.ABCMeta):
                     "1M", "1m" - one month
                     pd.Timedelta(hours=3, minutes=30) - three and a half
                         hours
+                    pd.timedelta(hours=1, minutes=20) - one hour and twenty
+                        minutes
 
             Intervals representing months must be defined as a string.
 

--- a/src/market_prices/prices/yahoo.py
+++ b/src/market_prices/prices/yahoo.py
@@ -289,11 +289,11 @@ class PricesYahoo(base.PricesBase):
     BaseInterval = intervals._BaseInterval(  # pylint: disable=protected-access
         "BaseInterval",
         dict(
-            T1=pd.Timedelta(1, "T"),
-            T2=pd.Timedelta(2, "T"),
-            T5=pd.Timedelta(5, "T"),
-            H1=pd.Timedelta(1, "H"),
-            D1=pd.Timedelta(1, "D"),
+            T1=intervals.TIMEDELTA_ARGS["T1"],
+            T2=intervals.TIMEDELTA_ARGS["T2"],
+            T5=intervals.TIMEDELTA_ARGS["T5"],
+            H1=intervals.TIMEDELTA_ARGS["H1"],
+            D1=intervals.TIMEDELTA_ARGS["D1"],
         ),
     )
 

--- a/src/market_prices/utils/calendar_utils.py
+++ b/src/market_prices/utils/calendar_utils.py
@@ -1157,7 +1157,7 @@ class _CompositeNonTradingIndex:
             # last value of last close is last calendar close (there is no next open)
             if last_close_.iloc[-1] == self.cc.closes[-1].tz_convert(None):
                 index = pd.IntervalIndex.from_arrays(
-                    last_close_[:-1], next_open.dropna(), "left"
+                    last_close_.iloc[:-1], next_open.dropna(), "left"
                 )
             else:
                 raise

--- a/src/market_prices/utils/pandas_utils.py
+++ b/src/market_prices/utils/pandas_utils.py
@@ -408,7 +408,7 @@ def interval_of_intervals(
     >>> interval_of_intervals(index)
     Interval('2021-05-01 12:00:00', '2021-05-01 16:30:00', closed='right')
     """
-    if not intervals.is_monotonic:
+    if not intervals.is_monotonic_increasing:
         raise ValueError(f"`intervals` must be monotonic. Received as '{intervals}'.")
     return pd.Interval(intervals[0].left, intervals[-1].right, closed=closed)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,11 +10,11 @@ Tests for the base module that require price data to be requested are on
 
 from __future__ import annotations
 
-import itertools
-import dataclasses
-import typing
 from collections import abc
+import dataclasses
+import itertools
 import re
+import typing
 
 import exchange_calendars as xcals
 import numpy as np
@@ -35,7 +35,7 @@ from .utils import get_resource
 # pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
 # pylint: disable=too-many-public-methods, too-many-arguments, too-many-locals
 # pylint: disable=too-many-statements
-# pylint: disable=protected-access, no-self-use, unused-argument, invalid-name
+# pylint: disable=protected-access, unused-argument, invalid-name
 #   missing-fuction-docstring: doc not required for all tests
 #   protected-access: not required for tests
 #   not compatible with use of fixtures to parameterize tests:
@@ -361,10 +361,10 @@ def PricesMock(daily_limit) -> abc.Iterator[type[m.PricesBase]]:
         BaseInterval = intervals._BaseInterval(
             "BaseInterval",
             dict(
-                T1=pd.Timedelta(1, "T"),
-                T5=pd.Timedelta(5, "T"),
-                H1=pd.Timedelta(1, "H"),
-                D1=pd.Timedelta(1, "D"),
+                T1=intervals.TIMEDELTA_ARGS["T1"],
+                T5=intervals.TIMEDELTA_ARGS["T5"],
+                H1=intervals.TIMEDELTA_ARGS["H1"],
+                D1=intervals.TIMEDELTA_ARGS["D1"],
             ),
         )
 
@@ -532,9 +532,9 @@ class TestPricesBaseSetup:
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
                 dict(
-                    T1=pd.Timedelta(1, "T"),
-                    T5=pd.Timedelta(5, "T"),
-                    H1=pd.Timedelta(1, "H"),
+                    T1=intervals.TIMEDELTA_ARGS["T1"],
+                    T5=intervals.TIMEDELTA_ARGS["T5"],
+                    H1=intervals.TIMEDELTA_ARGS["H1"],
                 ),
             )
 
@@ -712,8 +712,8 @@ class TestPricesBaseSetup:
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
                 dict(
-                    T5=pd.Timedelta(5, "T"),
-                    H1=pd.Timedelta(1, "H"),
+                    T5=intervals.TIMEDELTA_ARGS["T5"],
+                    H1=intervals.TIMEDELTA_ARGS["H1"],
                 ),
             )
 
@@ -734,9 +734,9 @@ class TestPricesBaseSetup:
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
                 dict(
-                    T5=pd.Timedelta(5, "T"),
-                    H1=pd.Timedelta(1, "H"),
-                    D1=pd.Timedelta(1, "D"),
+                    T5=intervals.TIMEDELTA_ARGS["T5"],
+                    H1=intervals.TIMEDELTA_ARGS["H1"],
+                    D1=intervals.TIMEDELTA_ARGS["D1"],
                 ),
             )
 
@@ -791,7 +791,7 @@ class TestPricesBaseSetup:
 
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
-                dict(D1=pd.Timedelta(1, "D")),
+                dict(D1=intervals.TIMEDELTA_ARGS["D1"]),
             )
 
             BASE_LIMITS = {BaseInterval.D1: limit}
@@ -808,7 +808,7 @@ class TestPricesBaseSetup:
 
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
-                dict(D1=pd.Timedelta(1, "D")),
+                dict(D1=intervals.TIMEDELTA_ARGS["D1"]),
             )
 
             BASE_LIMITS = {BaseInterval.D1: limit}
@@ -1130,9 +1130,9 @@ class TestPricesBaseSetup:
             )
             assert prices._earliest_requestable_calendar_minute(cal) == cal.first_minute
 
-        session = max([cal.first_session for cal in calendars])
+        session = max(cal.first_session for cal in calendars)
         assert prices.earliest_requestable_session == session
-        minute = max([cal.first_minute for cal in calendars])
+        minute = max(cal.first_minute for cal in calendars)
         assert prices.earliest_requestable_minute == minute
 
         prices = PricesMockNoDaily(symbols, calendars)
@@ -1369,7 +1369,7 @@ class TestPricesBaseSetup:
         expected = pd.Series(True, index=sessions)
         # although there are a couple of early closes that are not aligned with 1H
         dates = ["2021-12-24", "2021-12-31"]
-        expected[dates] = False  # type: ignore[call-overload]
+        expected[dates] = False
         assert_series_equal(prices._indexes_status[bi], expected)
 
         # XASX combined with xlon.
@@ -1792,14 +1792,14 @@ class TestBis:
             BaseInterval = intervals._BaseInterval(
                 "BaseInterval",
                 dict(
-                    T1=pd.Timedelta(1, "T"),
-                    T2=pd.Timedelta(2, "T"),
-                    T5=pd.Timedelta(5, "T"),
-                    T10=pd.Timedelta(10, "T"),
-                    T15=pd.Timedelta(15, "T"),
-                    T30=pd.Timedelta(30, "T"),
-                    H1=pd.Timedelta(1, "H"),
-                    D1=pd.Timedelta(1, "D"),
+                    T1=intervals.TIMEDELTA_ARGS["T1"],
+                    T2=intervals.TIMEDELTA_ARGS["T2"],
+                    T5=intervals.TIMEDELTA_ARGS["T5"],
+                    T10=intervals.TIMEDELTA_ARGS["T10"],
+                    T15=intervals.TIMEDELTA_ARGS["T15"],
+                    T30=intervals.TIMEDELTA_ARGS["T30"],
+                    H1=intervals.TIMEDELTA_ARGS["H1"],
+                    D1=intervals.TIMEDELTA_ARGS["D1"],
                 ),
             )
 
@@ -1873,7 +1873,7 @@ class TestBis:
         self,
         GetterMock: type[daterange.GetterIntraday],
         cc: calutils.CompositeCalendar,
-        start: pd.Timstamp,
+        start: pd.Timestamp,
         end: pd.Timestamp,
         **kwargs,
     ) -> daterange.GetterIntraday:

--- a/tests/test_base_prices.py
+++ b/tests/test_base_prices.py
@@ -1824,7 +1824,7 @@ class TestForcePartialIndices:
         assert index_forced.right[bv].isin(closes).all()
         # assert that all changed table indices had right > corresponding session close
         changed_indices_sessions = table.pt.sessions(cal)[bv]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             assert (indice.left < cal.session_close(session)) & (
                 indice.right > cal.session_close(session)
             )
@@ -1861,7 +1861,7 @@ class TestForcePartialIndices:
 
         # assert all changed table indices had left < corresponding lon session open
         changed_indices_sessions = table.pt.sessions(prices.cc, direction="next")[bv]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             assert (indice.left < xlon.session_open(session)) & (
                 indice.right > xlon.session_open(session)
             )
@@ -1878,7 +1878,7 @@ class TestForcePartialIndices:
         assert index_forced.right[bv].isin(closes).all()
         # assert that all changed table indices had right > corresponding session close
         changed_indices_sessions = table.pt.sessions(prices.cc)[bv]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             if xnys.is_session(session):
                 us_close = (indice.left < xnys.session_close(session)) & (
                     indice.right > xnys.session_close(session)
@@ -1940,14 +1940,14 @@ class TestForcePartialIndices:
         # assert all table indices with changed left side had left < corresponding
         # pm subsession open.
         changed_indices_sessions = table.pt.sessions(cal)[bv_left]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             break_end = cal.session_break_end(session)
             assert (indice.left < break_end) & (indice.right > break_end)
 
         # assert all table indices with changed right side had right > corresponding
         # (sub)session close.
         changed_indices_sessions = table.pt.sessions(cal)[bv_right]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             if cal.session_has_break(session):
                 break_start = cal.session_break_start(session)
                 am_close = (indice.left < break_start) & (indice.right > break_start)
@@ -2003,13 +2003,13 @@ class TestForcePartialIndices:
         # assert all table indices with changed left side had left < corresponding
         # xhkg pm open.
         changed_indices_sessions = table.pt.sessions(prices.cc)[bv_left]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             break_end = xhkg.session_break_end(session)
             assert (indice.left < break_end) & (indice.right > break_end)
 
         # assert all changed table indices had right > corresponding (sub)session close.
         changed_indices_sessions = table.pt.sessions(prices.cc)[bv_right]
-        for indice, session in changed_indices_sessions.iteritems():
+        for indice, session in changed_indices_sessions.items():
             if bvmf.is_session(session):
                 bvmf_close = bvmf.session_close(session)
                 brz_close = (indice.left < bvmf_close) & (indice.right > bvmf_close)

--- a/tests/test_base_prices.py
+++ b/tests/test_base_prices.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections import abc
 import datetime
+from datetime import timedelta
 import itertools
 from typing import Tuple, Dict, Literal
 import re
@@ -122,11 +123,11 @@ class PricesBaseTst(m.PricesBase):
     BaseInterval = intervals._BaseInterval(
         "BaseInterval",
         dict(
-            T1=pd.Timedelta(1, "T"),
-            T2=pd.Timedelta(2, "T"),
-            T5=pd.Timedelta(5, "T"),
-            H1=pd.Timedelta(1, "H"),
-            D1=pd.Timedelta(1, "D"),
+            T1=intervals.TIMEDELTA_ARGS["T1"],
+            T2=intervals.TIMEDELTA_ARGS["T2"],
+            T5=intervals.TIMEDELTA_ARGS["T5"],
+            H1=intervals.TIMEDELTA_ARGS["H1"],
+            D1=intervals.TIMEDELTA_ARGS["D1"],
         ),
     )
 
@@ -151,7 +152,7 @@ class PricesBaseTst(m.PricesBase):
             # verify that prices_tables are for symbols
             assert set(prices_tables["T1"].pt.symbols) == set(symbols)
 
-        earliest = min([TST_SYMBOLS[symbol].earliest_date for symbol in symbols])
+        earliest = min(TST_SYMBOLS[symbol].earliest_date for symbol in symbols)
         self._update_base_limits({self.BaseInterval.D1: earliest})
         calendars = [TST_SYMBOLS[symbol].calendar for symbol in symbols]
         delays = [TST_SYMBOLS[symbol].delay for symbol in symbols]
@@ -974,7 +975,7 @@ def assert_bounds(df: pd.DataFrame, bounds: tuple[pd.Timestamp, pd.Timestamp]):
 
 def assertions_intraday(
     df: pd.DataFrame,
-    interval: pd.TDInterval,
+    interval: TDInterval,
     prices: PricesBaseTst,
     start: pd.Timestamp,
     end: pd.Timestamp,
@@ -2399,7 +2400,7 @@ class TestGet:
         """
         prices = prices_us
         cal = prices.calendar_default
-        interval = pd.Timedelta(5, "T")
+        interval = timedelta(minutes=5)
 
         anchor = "workback"
         msg = "Cannot force close when anchor is 'workback'."
@@ -4237,7 +4238,7 @@ class TestGet:
             " The following base intervals could represent the end indice with the"
             " greatest possible accuracy although have insufficient data available"
             f" to cover the full period:\n\t{[bi]}.\nThe earliest minute from which"
-            f" data is available at 0 days 00:05:00 is {earliest_minute}, although"
+            f" data is available at 0:05:00 is {earliest_minute}, although"
             " at this base interval the requested period evaluates to"
             f" {drg.daterange[0]}."
             f"\nPeriod evaluated from parameters: {prices.gpp.pp_raw}."
@@ -4438,7 +4439,7 @@ class TestPriceAt:
         # verify raises error if `minute` oob
         limit_left_session = prices.limits[prices.bis.D1][0]
         limit_left = max(
-            [c.session_open(limit_left_session) for c in prices.calendars_unique]
+            c.session_open(limit_left_session) for c in prices.calendars_unique
         )
         df_left_limit = prices.price_at(limit_left)  # at limit
         assert df_left_limit.index[0] == limit_left

--- a/tests/test_tutorial_helpers.py
+++ b/tests/test_tutorial_helpers.py
@@ -21,7 +21,7 @@ import market_prices.support.tutorial_helpers as m
 # pylint: disable=missing-param-doc, missing-any-param-doc, redefined-outer-name
 # pylint: disable=too-many-public-methods, too-many-arguments, too-many-locals
 # pylint: disable=too-many-statements
-# pylint: disable=protected-access, no-self-use, unused-argument, invalid-name
+# pylint: disable=protected-access, unused-argument, invalid-name
 #   missing-fuction-docstring - doc not required for all tests
 #   protected-access not required for tests
 #   not compatible with use of fixtures to parameterize tests:
@@ -60,17 +60,17 @@ def PricesMock() -> abc.Iterator[type[PricesBase]]:
     class PricesMock_(PricesBase):
         """Mock of PricesBase with T1 and T5 base intervals defined."""
 
-        BaseInterval = intervals._BaseInterval(  # type: ignore[assignment]
+        BaseInterval = intervals._BaseInterval(
             "BaseInterval",
             dict(
-                T1=pd.Timedelta(1, "T"),
-                T5=pd.Timedelta(5, "T"),
+                T1=intervals.TIMEDELTA_ARGS["T1"],
+                T5=intervals.TIMEDELTA_ARGS["T5"],
             ),
         )
 
         BASE_LIMITS = {
-            BaseInterval.T1: T("2021-12-01 00:01", tz=UTC),  # type: ignore[has-type]
-            BaseInterval.T5: T("2021-11-01 00:01", tz=UTC),  # type: ignore[has-type]
+            BaseInterval.T1: T("2021-12-01 00:01", tz=UTC),
+            BaseInterval.T5: T("2021-11-01 00:01", tz=UTC),
         }
 
         def _request_data(self, *_, **__):


### PR DESCRIPTION
Fixes #89

Implements change of data-type for `intervals._TDIntervalBase` to `timedelta` from `pd.Timedelta`. This resolves [this issue](https://github.com/pandas-dev/pandas/issues/48908).

Also:
- Updates dependencies.
- Fixes new `pandas` deprecation and future warnings.