### PR TITLE
Update dependencies / revisions to support pandas 2.0

### DIFF
--- a/etc/requirements/requirements.txt
+++ b/etc/requirements/requirements.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.2.5
+exchange-calendars==4.2.6
     # via market-prices (pyproject.toml)
 idna==3.4
     # via requests
@@ -23,20 +23,20 @@ numpy==1.24.2
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==1.5.3
+pandas==2.0.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pydantic==1.10.5
+pydantic==1.10.7
     # via market-prices (pyproject.toml)
-pyluach==2.1.0
+pyluach==2.2.0
     # via exchange-calendars
 python-dateutil==2.8.2
     # via
     #   exchange-calendars
     #   pandas
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -49,11 +49,13 @@ six==1.16.0
     # via python-dateutil
 toolz==0.12.0
     # via exchange-calendars
-tqdm==4.64.1
+tqdm==4.65.0
     # via yahooquery
 typing-extensions==4.5.0
     # via pydantic
-urllib3==1.26.14
+tzdata==2023.3
+    # via pandas
+urllib3==1.26.15
     # via requests
-yahooquery==2.3.0
+yahooquery==2.3.1
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-astroid==2.14.2
+astroid==2.15.2
     # via pylint
 attrs==22.2.0
     # via
     #   hypothesis
     #   pytest
-black==23.1.0
+black==23.3.0
     # via market-prices
 blosc2==2.0.0
     # via tables
@@ -20,7 +20,7 @@ certifi==2022.12.7
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -33,21 +33,21 @@ colorama==0.4.6
     #   pylint
     #   pytest
     #   tqdm
-cython==0.29.33
+cython==0.29.34
     # via tables
 dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.2.5
+exchange-calendars==4.2.6
     # via
     #   market-prices
     #   market-prices (pyproject.toml)
-filelock==3.9.0
+filelock==3.11.0
     # via virtualenv
 flake8==6.0.0
     # via
@@ -55,9 +55,9 @@ flake8==6.0.0
     #   market-prices
 flake8-docstrings==1.7.0
     # via market-prices
-hypothesis==6.68.2
+hypothesis==6.71.0
     # via market-prices
-identify==2.5.18
+identify==2.5.22
     # via pre-commit
 idna==3.4
     # via requests
@@ -71,15 +71,15 @@ lazy-object-proxy==1.9.0
     # via astroid
 lxml==4.9.2
     # via yahooquery
-market-prices[tests]==0.10
+market-prices[tests]==0.10.1
     # via market-prices (pyproject.toml)
 mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-msgpack==1.0.4
+msgpack==1.0.5
     # via blosc2
-mypy==1.0.1
+mypy==1.2.0
     # via market-prices (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -104,32 +104,32 @@ packaging==23.0
     #   build
     #   pytest
     #   tables
-pandas==1.5.3
+pandas==2.0.0
     # via
     #   exchange-calendars
     #   market-prices
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==1.5.3.230214
+pandas-stubs==1.5.3.230321
     # via market-prices (pyproject.toml)
-pathspec==0.11.0
+pathspec==0.11.1
     # via black
-pip-tools==6.12.2
+pip-tools==6.13.0
     # via market-prices (pyproject.toml)
-platformdirs==3.0.0
+platformdirs==3.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==3.0.4
+pre-commit==3.2.2
     # via market-prices (pyproject.toml)
 py-cpuinfo==9.0.0
     # via tables
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.5
+pydantic==1.10.7
     # via
     #   market-prices
     #   market-prices (pyproject.toml)
@@ -137,13 +137,13 @@ pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.0.1
     # via flake8
-pylint==2.16.2
+pylint==2.17.2
     # via market-prices (pyproject.toml)
-pyluach==2.1.0
+pyluach==2.2.0
     # via exchange-calendars
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   market-prices
     #   pytest-mock
@@ -153,7 +153,7 @@ python-dateutil==2.8.2
     # via
     #   exchange-calendars
     #   pandas
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   exchange-calendars
     #   market-prices
@@ -181,13 +181,13 @@ tomli==2.0.1
     #   pylint
     #   pyproject-hooks
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 toolz==0.12.0
     # via exchange-calendars
-tqdm==4.64.1
+tqdm==4.65.0
     # via yahooquery
-types-pytz==2022.7.1.0
+types-pytz==2023.3.0.0
     # via
     #   market-prices
     #   pandas-stubs
@@ -198,15 +198,17 @@ typing-extensions==4.5.0
     #   mypy
     #   pydantic
     #   pylint
-urllib3==1.26.14
+tzdata==2023.3
+    # via pandas
+urllib3==1.26.15
     # via requests
-virtualenv==20.19.0
+virtualenv==20.21.0
     # via pre-commit
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid
-yahooquery==2.3.0
+yahooquery==2.3.1
     # via
     #   market-prices
     #   market-prices (pyproject.toml)

--- a/etc/requirements_tests.txt
+++ b/etc/requirements_tests.txt
@@ -8,13 +8,13 @@ attrs==22.2.0
     # via
     #   hypothesis
     #   pytest
-black==23.1.0
+black==23.3.0
     # via market-prices (pyproject.toml)
 blosc2==2.0.0
     # via tables
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via black
@@ -23,13 +23,13 @@ colorama==0.4.6
     #   click
     #   pytest
     #   tqdm
-cython==0.29.33
+cython==0.29.34
     # via tables
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.2.5
+exchange-calendars==4.2.6
     # via market-prices (pyproject.toml)
 flake8==6.0.0
     # via
@@ -37,7 +37,7 @@ flake8==6.0.0
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.68.2
+hypothesis==6.71.0
     # via market-prices (pyproject.toml)
 idna==3.4
     # via requests
@@ -49,7 +49,7 @@ lxml==4.9.2
     # via yahooquery
 mccabe==0.7.0
     # via flake8
-msgpack==1.0.4
+msgpack==1.0.5
     # via blosc2
 mypy-extensions==1.0.0
     # via black
@@ -67,14 +67,14 @@ packaging==23.0
     #   black
     #   pytest
     #   tables
-pandas==1.5.3
+pandas==2.0.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pathspec==0.11.0
+pathspec==0.11.1
     # via black
-platformdirs==3.0.0
+platformdirs==3.2.0
     # via black
 pluggy==1.0.0
     # via pytest
@@ -82,15 +82,15 @@ py-cpuinfo==9.0.0
     # via tables
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.5
+pydantic==1.10.7
     # via market-prices (pyproject.toml)
 pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.0.1
     # via flake8
-pyluach==2.1.0
+pyluach==2.2.0
     # via exchange-calendars
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
@@ -100,7 +100,7 @@ python-dateutil==2.8.2
     # via
     #   exchange-calendars
     #   pandas
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -123,15 +123,17 @@ tomli==2.0.1
     #   pytest
 toolz==0.12.0
     # via exchange-calendars
-tqdm==4.64.1
+tqdm==4.65.0
     # via yahooquery
-types-pytz==2022.7.1.0
+types-pytz==2023.3.0.0
     # via market-prices (pyproject.toml)
 typing-extensions==4.5.0
     # via
     #   black
     #   pydantic
-urllib3==1.26.14
+tzdata==2023.3
+    # via pandas
+urllib3==1.26.15
     # via requests
-yahooquery==2.3.0
+yahooquery==2.3.1
     # via market-prices (pyproject.toml)

--- a/src/market_prices/utils/pandas_utils.py
+++ b/src/market_prices/utils/pandas_utils.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 import pydantic
-from pytz.tzinfo import BaseTzInfo
+import pytz
 
 from market_prices import mptypes
 
@@ -461,7 +461,7 @@ def remove_intervals_from_interval(
 
 @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
 def interval_index_new_tz(
-    index: mptypes.IntervalDatetimeIndex, tz: Union[BaseTzInfo, str, None]
+    index: mptypes.IntervalDatetimeIndex, tz: Union[pytz.tzinfo.BaseTzInfo, str, None]
 ) -> pd.IntervalIndex:
     """Return pd.IntervalIndex with different timezone.
 
@@ -495,7 +495,7 @@ def interval_index_new_tz(
     >>> index = pd.IntervalIndex.from_arrays(left, right)
     >>> index.right.tz
     <DstTzInfo 'US/Central' LMT-1 day, 18:09:00 STD>
-    >>> new_index = interval_index_new_tz(index, tz="UTC")
+    >>> new_index = interval_index_new_tz(index, tz=pytz.UTC)
     >>> new_index.left.tz.zone == new_index.right.tz.zone == "UTC"
     True
     """

--- a/tests/test_calendar_utils.py
+++ b/tests/test_calendar_utils.py
@@ -321,7 +321,6 @@ class CompositeAnswers:
             self.ANSWERS_BASE_PATH + filename,
             index_col=0,
             parse_dates=[0, 1, 2, 3, 4],
-            infer_datetime_format=True,
         )
         # Necessary for csv saved prior to xcals v4.0
         if df.index.tz is not None:

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -6,6 +6,7 @@ import re
 
 import pandas as pd
 import pytest
+import pytz
 
 import market_prices.utils.pandas_utils as m
 
@@ -124,7 +125,7 @@ def test_make_non_overlapping(
     pd.testing.assert_index_equal(rtrn, expected)
 
     # test non tz_naive index
-    index = m.interval_index_new_tz(index, "UTC")
+    index = m.interval_index_new_tz(index, pytz.UTC)
     rtrn = test_method(index, fully_overlapped="remove")
     expected = index.drop(index[i])
     pd.testing.assert_index_equal(rtrn, expected)

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -330,7 +330,7 @@ class TestConstructorErrors:
         intraday_df = intraday_pt.copy()
         intraday_df.index = pd.interval_range(start=0, periods=len(intraday_pt), freq=1)
 
-        with pytest.raises(TypeError, match=match + "numeric.Int64Index'>."):
+        with pytest.raises(TypeError, match=match + "base.Index'>."):
             _ = intraday_df.pt
 
         daily_df = daily_pt.copy()

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -1008,7 +1008,7 @@ class TestConstructor:
         PricesYahoo with `adj_close` parameter passed as False (default)
         and True. For each tested interval, test requests a single
         dataframe from yahooquery and then mocks the return from
-        `PricesYahoo._yq_history` to return this single source. The effect
+        `PricesYahoo._ticker.history` to return this single source. The effect
         of `adj_close` is then tested against the return from
         `PricesYahoo._request_yahoo`. Why not just test the difference
         in the return from `_request_yahoo` without the mocking? Because
@@ -1040,7 +1040,7 @@ class TestConstructor:
         )
 
         def mock_yq_history(prices: m.PricesYahoo, df: pd.DataFrame):
-            prices._ya_history = lambda *_, **__: df.copy()
+            prices._ticker.history = lambda *_, **__: df.copy()
 
         # test daily interval results in different "close" column
         mock_yq_history(prices, df_yq)


### PR DESCRIPTION
Revisions for errors and warnings raised with pandas 2.0.

Accommodates pandas change in default timezone from `pytz.UTC` to `datetime.timezone.utc`. (`market_prices` continues to use `pytz` to represent all timezones.)

Updates dependencies including to:
* pandas 2.0
* exchange_calendars 4.2.6
* yahooquery 2.3.1