### PR TITLE
Fix bug following yahoo API change to 'quotes' endpoint

### DIFF
--- a/src/market_prices/prices/config/config_yahoo.py
+++ b/src/market_prices/prices/config/config_yahoo.py
@@ -40,6 +40,7 @@ EXCHANGE_TO_CALENDAR: dict = {
     "Nasdaq GIDS": "NASDAQ",
     "NYSE": "XNYS",
     "NYSEArca": "XNYS",
+    "NY Mercantile": "us_futures",
     "BATS": "XNYS",
     "DJI": "XNYS",
     "SNP": "XNYS",


### PR DESCRIPTION
The Yahoo API 'quotes' endpoint has seemingly been moved to a new address which requires a valid cookie (crumb) to access. See https://github.com/dpguthrie/yahooquery/issues/178.

This PR changes source for exchange name to 'prices' endpoint.