### PR TITLE
Reinstate fix for bug following yahoo API change / Update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://test.pypi.org/simple --pre market_prices | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in test index, i is $i, sleeping 5s"; sleep 5s; ((i++)); echo "next i is $i"; done
+          do echo "waiting for package to appear in test index, i is $i, sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
         pip install --index-url https://test.pypi.org/simple market_prices==${{ github.ref_name }} --no-deps
         pip install -r etc/requirements/requirements.txt
         python -c 'import market_prices;print(market_prices.__version__)'
@@ -58,6 +58,6 @@ jobs:
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://pypi.org/simple --pre market_prices | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in index, i is $i, sleeping 5s"; sleep 5s; ((i++)); echo "next i is $i"; done
+          do echo "waiting for package to appear in index, i is $i, sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
         pip install --index-url https://pypi.org/simple market_prices==${{ github.ref_name }}
         python -c 'import market_prices;print(market_prices.__version__)'

--- a/etc/requirements/requirements.txt
+++ b/etc/requirements/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=etc/requirements/requirements.txt pyproject.toml
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.2.6
+exchange-calendars==4.2.8
     # via market-prices (pyproject.toml)
 idna==3.4
     # via requests
@@ -18,17 +18,17 @@ korean-lunar-calendar==0.3.1
     # via exchange-calendars
 lxml==4.9.2
     # via yahooquery
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==2.0.0
+pandas==2.0.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pydantic==1.10.7
+pydantic==1.10.8
     # via market-prices (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars
@@ -41,7 +41,7 @@ pytz==2023.3
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-requests==2.28.2
+requests==2.31.0
     # via requests-futures
 requests-futures==1.0.0
     # via yahooquery
@@ -51,11 +51,11 @@ toolz==0.12.0
     # via exchange-calendars
 tqdm==4.65.0
     # via yahooquery
-typing-extensions==4.5.0
+typing-extensions==4.6.1
     # via pydantic
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 yahooquery==2.3.1
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,19 +4,17 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-astroid==2.15.2
+astroid==2.15.5
     # via pylint
-attrs==22.2.0
-    # via
-    #   hypothesis
-    #   pytest
+attrs==23.1.0
+    # via hypothesis
 black==23.3.0
     # via market-prices
 blosc2==2.0.0
     # via tables
 build==0.10.0
     # via pip-tools
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cfgv==3.3.1
     # via pre-commit
@@ -33,7 +31,7 @@ colorama==0.4.6
     #   pylint
     #   pytest
     #   tqdm
-cython==0.29.34
+cython==0.29.35
     # via tables
 dill==0.3.6
     # via pylint
@@ -43,11 +41,11 @@ exceptiongroup==1.1.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.2.6
+exchange-calendars==4.2.8
     # via
     #   market-prices
     #   market-prices (pyproject.toml)
-filelock==3.11.0
+filelock==3.12.0
     # via virtualenv
 flake8==6.0.0
     # via
@@ -55,9 +53,9 @@ flake8==6.0.0
     #   market-prices
 flake8-docstrings==1.7.0
     # via market-prices
-hypothesis==6.71.0
+hypothesis==6.75.3
     # via market-prices
-identify==2.5.22
+identify==2.5.24
     # via pre-commit
 idna==3.4
     # via requests
@@ -71,7 +69,7 @@ lazy-object-proxy==1.9.0
     # via astroid
 lxml==4.9.2
     # via yahooquery
-market-prices[tests]==0.10.1
+market-prices[tests]==0.10.2
     # via market-prices (pyproject.toml)
 mccabe==0.7.0
     # via
@@ -79,18 +77,18 @@ mccabe==0.7.0
     #   pylint
 msgpack==1.0.5
     # via blosc2
-mypy==1.2.0
+mypy==1.3.0
     # via market-prices (pyproject.toml)
 mypy-extensions==1.0.0
     # via
     #   black
     #   market-prices (pyproject.toml)
     #   mypy
-nodeenv==1.7.0
+nodeenv==1.8.0
     # via pre-commit
 numexpr==2.8.4
     # via tables
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   exchange-calendars
     #   market-prices
@@ -98,38 +96,38 @@ numpy==1.24.2
     #   numexpr
     #   pandas
     #   tables
-packaging==23.0
+packaging==23.1
     # via
     #   black
     #   build
     #   pytest
     #   tables
-pandas==2.0.0
+pandas==2.0.1
     # via
     #   exchange-calendars
     #   market-prices
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==1.5.3.230321
+pandas-stubs==2.0.1.230501
     # via market-prices (pyproject.toml)
 pathspec==0.11.1
     # via black
 pip-tools==6.13.0
     # via market-prices (pyproject.toml)
-platformdirs==3.2.0
+platformdirs==3.5.1
     # via
     #   black
     #   pylint
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==3.2.2
+pre-commit==3.3.2
     # via market-prices (pyproject.toml)
 py-cpuinfo==9.0.0
     # via tables
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.7
+pydantic==1.10.8
     # via
     #   market-prices
     #   market-prices (pyproject.toml)
@@ -137,13 +135,13 @@ pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.0.1
     # via flake8
-pylint==2.17.2
+pylint==2.17.4
     # via market-prices (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   market-prices
     #   pytest-mock
@@ -161,7 +159,7 @@ pytz==2023.3
     #   pandas
 pyyaml==6.0
     # via pre-commit
-requests==2.28.2
+requests==2.31.0
     # via requests-futures
 requests-futures==1.0.0
     # via yahooquery
@@ -181,7 +179,7 @@ tomli==2.0.1
     #   pylint
     #   pyproject-hooks
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 toolz==0.12.0
     # via exchange-calendars
@@ -191,7 +189,7 @@ types-pytz==2023.3.0.0
     # via
     #   market-prices
     #   pandas-stubs
-typing-extensions==4.5.0
+typing-extensions==4.6.1
     # via
     #   astroid
     #   black
@@ -200,9 +198,9 @@ typing-extensions==4.5.0
     #   pylint
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via pre-commit
 wheel==0.40.0
     # via pip-tools

--- a/etc/requirements_tests.txt
+++ b/etc/requirements_tests.txt
@@ -4,15 +4,13 @@
 #
 #    pip-compile --extra=tests --output-file=etc/requirements_tests.txt pyproject.toml
 #
-attrs==22.2.0
-    # via
-    #   hypothesis
-    #   pytest
+attrs==23.1.0
+    # via hypothesis
 black==23.3.0
     # via market-prices (pyproject.toml)
 blosc2==2.0.0
     # via tables
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -23,13 +21,13 @@ colorama==0.4.6
     #   click
     #   pytest
     #   tqdm
-cython==0.29.34
+cython==0.29.35
     # via tables
 exceptiongroup==1.1.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.2.6
+exchange-calendars==4.2.8
     # via market-prices (pyproject.toml)
 flake8==6.0.0
     # via
@@ -37,7 +35,7 @@ flake8==6.0.0
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.71.0
+hypothesis==6.75.3
     # via market-prices (pyproject.toml)
 idna==3.4
     # via requests
@@ -55,26 +53,26 @@ mypy-extensions==1.0.0
     # via black
 numexpr==2.8.4
     # via tables
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   numexpr
     #   pandas
     #   tables
-packaging==23.0
+packaging==23.1
     # via
     #   black
     #   pytest
     #   tables
-pandas==2.0.0
+pandas==2.0.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pathspec==0.11.1
     # via black
-platformdirs==3.2.0
+platformdirs==3.5.1
     # via black
 pluggy==1.0.0
     # via pytest
@@ -82,7 +80,7 @@ py-cpuinfo==9.0.0
     # via tables
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.7
+pydantic==1.10.8
     # via market-prices (pyproject.toml)
 pydocstyle==6.3.0
     # via flake8-docstrings
@@ -90,7 +88,7 @@ pyflakes==3.0.1
     # via flake8
 pyluach==2.2.0
     # via exchange-calendars
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
@@ -105,7 +103,7 @@ pytz==2023.3
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-requests==2.28.2
+requests==2.31.0
     # via requests-futures
 requests-futures==1.0.0
     # via yahooquery
@@ -127,13 +125,13 @@ tqdm==4.65.0
     # via yahooquery
 types-pytz==2023.3.0.0
     # via market-prices (pyproject.toml)
-typing-extensions==4.5.0
+typing-extensions==4.6.1
     # via
     #   black
     #   pydantic
 tzdata==2023.3
     # via pandas
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 yahooquery==2.3.1
     # via market-prices (pyproject.toml)

--- a/src/market_prices/prices/config/config_yahoo.py
+++ b/src/market_prices/prices/config/config_yahoo.py
@@ -40,6 +40,7 @@ EXCHANGE_TO_CALENDAR: dict = {
     "Nasdaq GIDS": "NASDAQ",
     "NYSE": "XNYS",
     "NYSEArca": "XNYS",
+    "NY Mercantile": "us_futures",
     "BATS": "XNYS",
     "DJI": "XNYS",
     "SNP": "XNYS",

--- a/src/market_prices/prices/yahoo.py
+++ b/src/market_prices/prices/yahoo.py
@@ -367,7 +367,11 @@ class PricesYahoo(base.PricesBase):
     def _yahoo_exchange_name(self) -> dict[str, str]:
         d = {}
         for s in self._ticker.symbols:
-            d[s] = self._ticker.quotes[s]["fullExchangeName"]
+            d[s] = self._ticker.price[s]["exchangeName"]
+            # the quotes endpoint's fullExchangeName was more comprehensive
+            # although endpoint went behind a cookie request on 23/04/20
+            # and again on 23/05/25.
+            # d[s] = self._ticker.quotes[s]["fullExchangeName"]
         return d
 
     def _ascertain_calendars(
@@ -388,8 +392,9 @@ class PricesYahoo(base.PricesBase):
                 cal = exchange
             elif exchange in self.YAHOO_EXCHANGE_TO_CALENDAR:
                 cal = self.YAHOO_EXCHANGE_TO_CALENDAR[exchange]
-            elif self._ticker.quotes[s]["market"] == "us24_market":
-                cal = "us_futures"
+            # see comment to _yahoo_exchange_name (lost quotes endpoint)
+            # elif self._ticker.quotes[s]["market"] == "us24_market":
+            #     cal = "us_futures"
             else:
                 msg = f"Unable to ascertain calendar for symbol '{s}'."
                 raise errors.CalendarError(msg)

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -50,6 +50,7 @@ UTC = pytz.UTC
 # ...sessions that yahoo temporarily fails to return prices for if (seemingly)
 # send a high frequency of requests for prices from the same IP address.
 _flakylist = (
+    pd.Timestamp("2023-04-23"),
     pd.Timestamp("2023-01-18"),
     pd.Timestamp("2023-01-17"),
     pd.Timestamp("2022-10-11"),


### PR DESCRIPTION
Around 2023-04-20 and subsequently from 2023-05-24 the quotes endpoint
was seemingly unavailable unless including a cookie to a new address.

See yahooquery issue 178.

Also:
* updates dependencies.
* adds print output to release workflow to better identify where the loop's failing (#153).
* updates flaky list.