### PR TITLE
Update dependencies and fix pandas 2.2 deprecation warnings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
@@ -39,7 +39,7 @@ jobs:
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://test.pypi.org/simple --pre market_prices | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in test index, i is $i"; echo "sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
+          do echo "waiting for package to appear in test index, i is $i"; echo "sleeping 5s"; sleep 5s; echo "woken up"; let i++; echo "next i is $i"; done
         pip install --index-url https://test.pypi.org/simple market_prices==${{ github.ref_name }} --no-deps
         pip install -r etc/requirements.txt
         python -c 'import market_prices;print(market_prices.__version__)'
@@ -60,6 +60,6 @@ jobs:
       run: |
         i=0
         while [ $i -lt 12 ] && [ "${{ github.ref_name }}" != $(pip index versions -i https://pypi.org/simple --pre market_prices | cut -d'(' -f2 | cut -d')' -f1 | sed 1q) ];\
-          do echo "waiting for package to appear in index, i is $i"; echo "sleeping 5s"; sleep 5s; echo "woken up"; ((i++)); echo "next i is $i"; done
+          do echo "waiting for package to appear in index, i is $i"; echo "sleeping 5s"; sleep 5s; echo "woken up"; let i++; echo "next i is $i"; done
         pip install --index-url https://pypi.org/simple market_prices==${{ github.ref_name }}
         python -c 'import market_prices;print(market_prices.__version__)'

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The above call was made 21 minutes after the NYSE open. Notice that the call ret
 Any interval can be evaluated (limited only by the availability of underlying data).
 ```python
 >>> # prices over a specific session at 68 minute intervals
->>> prices.get("68T", start="2022-06-27", end="2022-06-27", force=True)
+>>> prices.get("68min", start="2022-06-27", end="2022-06-27", force=True)
 ```
 ```
 symbol                                            MSFT
@@ -108,7 +108,7 @@ Although some indices are longer than three calendar days, they all comprise of 
 )
 >>> # lead_symbol determines the exchange against which the period will be evaluated and
 >>> # the default output time zone (which for Bitcoin is UTC).
->>> prices_mult.get("90T", hours=9, lead_symbol="BTC-USD")
+>>> prices_mult.get("90min", hours=9, lead_symbol="BTC-USD")
 ```
 ```
 symbol                                            MSFT                                                    9988.HK                                                       BTC-USD
@@ -127,7 +127,7 @@ By default prices are shown as missing when the exchange is closed (the time zon
 The `get` method has plenty of options to customize the output, including `fill` to fill in indices when an exchange is closed...
 ```python
 >>> # as before, only now filling in prices when exchanges are closed
->>> prices_mult.get("90T", hours=9, lead_symbol="BTC-USD", fill="both")
+>>> prices_mult.get("90min", hours=9, lead_symbol="BTC-USD", fill="both")
 ```
 ```
 symbol                                            MSFT                                                    9988.HK                                                       BTC-USD

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=etc/requirements.txt pyproject.toml
 #
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via yahooquery
 certifi==2023.11.17
     # via requests
@@ -12,7 +12,7 @@ charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.5.1
+exchange-calendars==4.5.2
     # via market-prices (pyproject.toml)
 idna==3.6
     # via requests
@@ -20,12 +20,12 @@ korean-lunar-calendar==0.3.1
     # via exchange-calendars
 lxml==4.9.4
     # via yahooquery
-numpy==1.26.2
+numpy==1.26.3
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==2.1.4
+pandas==2.2.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -33,10 +33,8 @@ pandas==2.1.4
 pyluach==2.2.0
     # via exchange-calendars
 python-dateutil==2.8.2
-    # via
-    #   exchange-calendars
-    #   pandas
-pytz==2023.3.post1
+    # via pandas
+pytz==2023.4
     # via pandas
 requests==2.31.0
     # via
@@ -48,7 +46,7 @@ six==1.16.0
     # via python-dateutil
 soupsieve==2.5
     # via beautifulsoup4
-toolz==0.12.0
+toolz==0.12.1
     # via exchange-calendars
 tqdm==4.66.1
     # via yahooquery
@@ -57,7 +55,7 @@ tzdata==2023.4
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.1.0
+urllib3==2.2.0
     # via requests
 valimp==0.2
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -6,11 +6,11 @@
 #
 attrs==23.2.0
     # via hypothesis
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via yahooquery
-black==23.12.1
+black==24.1.1
     # via market-prices (pyproject.toml)
-blosc2==2.4.0
+blosc2==2.5.1
     # via tables
 certifi==2023.11.17
     # via requests
@@ -27,15 +27,15 @@ exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.1
+exchange-calendars==4.5.2
     # via market-prices (pyproject.toml)
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.92.2
+hypothesis==6.97.3
     # via market-prices (pyproject.toml)
 idna==3.6
     # via requests
@@ -53,9 +53,9 @@ mypy-extensions==1.0.0
     # via black
 ndindex==1.7
     # via blosc2
-numexpr==2.8.8
+numexpr==2.9.0
     # via tables
-numpy==1.26.2
+numpy==1.26.3
     # via
     #   blosc2
     #   exchange-calendars
@@ -68,16 +68,16 @@ packaging==23.2
     #   black
     #   pytest
     #   tables
-pandas==2.1.4
+pandas==2.2.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pathspec==0.12.1
     # via black
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via black
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 py-cpuinfo==9.0.0
     # via
@@ -87,21 +87,19 @@ pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
 pyluach==2.2.0
     # via exchange-calendars
-pytest==7.4.4
+pytest==8.0.0
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
 pytest-mock==3.12.0
     # via market-prices (pyproject.toml)
 python-dateutil==2.8.2
-    # via
-    #   exchange-calendars
-    #   pandas
-pytz==2023.3.post1
+    # via pandas
+pytz==2023.4
     # via pandas
 requests==2.31.0
     # via
@@ -123,7 +121,7 @@ tomli==2.0.1
     # via
     #   black
     #   pytest
-toolz==0.12.0
+toolz==0.12.1
     # via exchange-calendars
 tqdm==4.66.1
     # via yahooquery
@@ -134,7 +132,7 @@ tzdata==2023.4
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.1.0
+urllib3==2.2.0
     # via requests
 valimp==0.2
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -8,11 +8,11 @@ astroid==3.0.2
     # via pylint
 attrs==23.2.0
     # via hypothesis
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via yahooquery
-black==23.12.1
+black==24.1.1
     # via market-prices (pyproject.toml)
-blosc2==2.4.0
+blosc2==2.5.1
     # via tables
 build==1.0.3
     # via pip-tools
@@ -33,7 +33,7 @@ colorama==0.4.6
     #   pylint
     #   pytest
     #   tqdm
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
@@ -41,17 +41,17 @@ exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.1
+exchange-calendars==4.5.2
     # via market-prices (pyproject.toml)
 filelock==3.13.1
     # via virtualenv
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.92.2
+hypothesis==6.97.3
     # via market-prices (pyproject.toml)
 identify==2.5.33
     # via pre-commit
@@ -84,9 +84,9 @@ ndindex==1.7
     # via blosc2
 nodeenv==1.8.0
     # via pre-commit
-numexpr==2.8.8
+numexpr==2.9.0
     # via tables
-numpy==1.26.2
+numpy==1.26.3
     # via
     #   blosc2
     #   exchange-calendars
@@ -101,7 +101,7 @@ packaging==23.2
     #   build
     #   pytest
     #   tables
-pandas==2.1.4
+pandas==2.2.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -112,12 +112,12 @@ pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via market-prices (pyproject.toml)
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 pre-commit==3.6.0
     # via market-prices (pyproject.toml)
@@ -129,7 +129,7 @@ pycodestyle==2.11.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
 pylint==3.0.3
     # via market-prices (pyproject.toml)
@@ -137,17 +137,15 @@ pyluach==2.2.0
     # via exchange-calendars
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.4
+pytest==8.0.0
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
 pytest-mock==3.12.0
     # via market-prices (pyproject.toml)
 python-dateutil==2.8.2
-    # via
-    #   exchange-calendars
-    #   pandas
-pytz==2023.3.post1
+    # via pandas
+pytz==2023.4
     # via pandas
 pyyaml==6.0.1
     # via pre-commit
@@ -178,11 +176,11 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.3
     # via pylint
-toolz==0.12.0
+toolz==0.12.1
     # via exchange-calendars
 tqdm==4.66.1
     # via yahooquery
-types-pytz==2023.3.1.1
+types-pytz==2023.4.0.20240130
     # via pandas-stubs
 typing-extensions==4.9.0
     # via
@@ -195,7 +193,7 @@ tzdata==2023.4
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.1.0
+urllib3==2.2.0
     # via requests
 valimp==0.2
     # via market-prices (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 
 dependencies = [
     "exchange_calendars",
-    "numpy",
+    "numpy<2",
     "pandas",
     "tzdata",
     "yahooquery",

--- a/src/market_prices/data.py
+++ b/src/market_prices/data.py
@@ -659,7 +659,7 @@ class Data:
         elif self.bi.is_intraday:
             assert self._delay is not None
             # ten minutes to cover provider delays in publishing data.
-            rerequest_from = helpers.now() - self._delay - pd.Timedelta(10, "T")
+            rerequest_from = helpers.now() - self._delay - pd.Timedelta(10, "min")
             if end < rerequest_from:
                 return dr
             excess = end - rerequest_from

--- a/src/market_prices/daterange.py
+++ b/src/market_prices/daterange.py
@@ -866,7 +866,7 @@ class GetterIntraday(_Getter):
         # which the end is accurate as at the moment the end is requested.
         # (without the + one minute would be ignoring those price that have
         # come in since the current minute started.)
-        end_accuracy = min(end_accuracy, now + pd.Timedelta("1T"))
+        end_accuracy = min(end_accuracy, now + pd.Timedelta("1min"))
         return end, end_accuracy
 
     def _trading_index(
@@ -1055,7 +1055,7 @@ class GetterIntraday(_Getter):
 
         # "previous" to cover ts as close (not a trading minute).
         session = self.cal.minute_to_session(ts, "previous")
-        schedule_vals = self.cal.schedule.loc[session].dropna().view(np.int64).values
+        schedule_vals = self.cal.schedule.loc[session].dropna().astype(np.int64).values
         if ts.value in schedule_vals:
             target_i = self.cal.sessions.get_loc(session) + days
 
@@ -1199,7 +1199,7 @@ class GetterIntraday(_Getter):
             if intraday_duration:
                 if intraday_duration < self.final_interval.as_minutes:
                     raise errors.PricesUnavailableIntervalDurationError(
-                        pd.Timedelta(intraday_duration, "T"), self
+                        pd.Timedelta(intraday_duration, "min"), self
                     )
                 if start is None:
                     end_ = end
@@ -1269,7 +1269,7 @@ class GetterIntraday(_Getter):
             else:
                 minutes = calutils.minutes_in_period(self.cal, start, end_)
             if self.final_interval.as_minutes > minutes:
-                period_duration = pd.Timedelta(minutes, "T")
+                period_duration = pd.Timedelta(minutes, "min")
                 raise errors.PricesUnavailableIntervalPeriodError(
                     self, start, end_, period_duration
                 )

--- a/src/market_prices/errors.py
+++ b/src/market_prices/errors.py
@@ -872,10 +872,10 @@ class PricesMissingWarning(PricesWarning):
 
     def __init__(self, symbol: str, bi: BI, sessions: pd.DatetimeIndex, source: str):
         date_format = "%Y-%m-%d"
-        sessions = sessions.format(date_format=date_format)
+        sessions_ = sessions.strftime(date_format).tolist()
         self._msg = (
             f"Prices from {source} are missing for '{symbol}' at the"
-            f" base interval '{bi}' for the following sessions: {sessions}."
+            f" base interval '{bi}' for the following sessions: {sessions_}."
         )
 
 

--- a/src/market_prices/helpers.py
+++ b/src/market_prices/helpers.py
@@ -23,8 +23,8 @@ if "pytest" in sys.modules:
 UTC = zoneinfo.ZoneInfo("UTC")
 
 ONE_DAY: pd.Timedelta = pd.Timedelta(1, "D")
-ONE_MIN: pd.Timedelta = pd.Timedelta(1, "T")
-ONE_SEC: pd.Timedelta = pd.Timedelta(1, "S")
+ONE_MIN: pd.Timedelta = pd.Timedelta(1, "min")
+ONE_SEC: pd.Timedelta = pd.Timedelta(1, "s")
 
 
 def symbols_to_list(symbols: mptypes.Symbols) -> list[str]:
@@ -155,7 +155,7 @@ def now(
         now_ = now_.tz_convert(None)
         res = "D"
     else:
-        res = "T"
+        res = "min"
     return now_.ceil(res) if side == "right" else now_.floor(res)
 
 
@@ -172,7 +172,7 @@ def extract_freq_parts(freq: str) -> tuple[int, str]:
     Parameters
     ----------
     freq
-        Pandas frequency, for example "5D", "30T", "4H", "33MS".
+        Pandas frequency, for example "5D", "30min", "4h", "33MS".
 
     Raises
     ------
@@ -192,8 +192,8 @@ def extract_freq_parts(freq: str) -> tuple[int, str]:
 
     Examples
     --------
-    >>> extract_freq_parts("22T")
-    (22, 'T')
+    >>> extract_freq_parts("22min")
+    (22, 'min')
     >>> extract_freq_parts("1m")
     (1, 'm')
     >>> extract_freq_parts("D")

--- a/src/market_prices/parsing.py
+++ b/src/market_prices/parsing.py
@@ -200,12 +200,12 @@ def _parse_start_end(
         start_is_date = helpers.is_date(start)
         if not start_is_date:
             # do not include any incomplete minute
-            start = start.ceil("T")
+            start = start.ceil("min")
     if end is not None:
         end_is_date = helpers.is_date(end)
         if not end_is_date:
             # do not include incomplete minute
-            end = end.floor("T")
+            end = end.floor("min")
         # if end > now, set to None.
         now_interval = intervals.ONE_DAY if end_is_date else intervals.ONE_MIN
         now = helpers.now(now_interval, "left")

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -1123,7 +1123,7 @@ class PricesBase(metaclass=abc.ABCMeta):
 
     def _set_delays(self, delays: int | list[int] | dict[str, int]):
         d = self._dict_for_all_symbols("delays", delays)
-        self._delays = {k: pd.Timedelta(v, "T") for k, v in d.items()}
+        self._delays = {k: pd.Timedelta(v, "min") for k, v in d.items()}
 
     @property
     def delays(self) -> dict[str, pd.Timedelta]:
@@ -1640,8 +1640,8 @@ class PricesBase(metaclass=abc.ABCMeta):
 
             index = self._trading_indexes[bi]
             nano_index = index.left.asi8
-            opens = self.cc.opens[slc].view("int64")
-            closes = self.cc.closes[slc].view("int64")
+            opens = self.cc.opens[slc].astype("int64")
+            closes = self.cc.closes[slc].astype("int64")
 
             sessions = opens.index
             srs = pd.Series(True, index=sessions)
@@ -3444,7 +3444,7 @@ class PricesBase(metaclass=abc.ABCMeta):
                     value:
                         one or more digits.
                     unit:
-                        "min", "t", "MIN" or "T" for minutes
+                        "min", "MIN", "T" or "t" for minutes
                         "h" or "H" for hours
                         "d" or "D' for days
                         'm' or "M" for months
@@ -3452,12 +3452,12 @@ class PricesBase(metaclass=abc.ABCMeta):
             Examples:
                 thirty minutes:
                     "30min", "30T"
-                    pd.Timedelta(30, "T"), pd.Timedelta(minutes=30)
+                    pd.Timedelta(30, "min"), pd.Timedelta(minutes=30)
                     timedelta(minutes=30)
 
                 three hours:
                     "3h", "3H"
-                    pd.Timedelta(3, "H"), pd.Timedelta(hours=3)
+                    pd.Timedelta(3, "h"), pd.Timedelta(hours=3)
                     timedelta(hours=3)
 
                 one day:
@@ -3854,8 +3854,8 @@ class PricesBase(metaclass=abc.ABCMeta):
                     greater than the interval although the indice bounds
                     they evaluate to do not. For example, if a session
                     opens at 09.00, `start` is 09.01 and `end` is 09.09
-                    then a call for data at a "5T" `interval` will evalute
-                    the period bounds as from 09.05 through 09.05.
+                    then a call for data at a "5min" `interval` will
+                    evalute the period bounds as from 09.05 through 09.05.
 
                 errors.PricesUnavailableDOIntervalPeriodError:
                     Monthly `interval` is longer than the evaluated period.

--- a/src/market_prices/prices/yahoo.py
+++ b/src/market_prices/prices/yahoo.py
@@ -560,7 +560,7 @@ class PricesYahoo(base.PricesBase):
     @staticmethod
     def _bi_to_source_key(interval: intervals.BI) -> str:
         """Map interval to value for source's interval parameter."""
-        if interval.freq_unit == "T":
+        if interval.freq_unit == "min":
             return str(interval.freq_value) + "m"
         else:
             return interval.as_pdfreq.lower()  # as yahooquery value
@@ -868,6 +868,6 @@ class PricesYahoo(base.PricesBase):
                 # 22 hours ensures markets opening in Americas included
                 # whilst avoiding including the following session of
                 # Australasian markets
-                end_ += pd.Timedelta(22, "H")
+                end_ += pd.Timedelta(22, "h")
             prices = self._request_yahoo(interval=interval, start=start, end=end_)
         return self._tidy_yahoo(prices, interval, start, end)

--- a/src/market_prices/utils/calendar_utils.py
+++ b/src/market_prices/utils/calendar_utils.py
@@ -240,7 +240,7 @@ class CompositeCalendar:
 
     LEFT_SIDES = ["left", "both"]
     RIGHT_SIDES = ["right", "both"]
-    ONE_MIN = pd.Timedelta(1, "T")
+    ONE_MIN = pd.Timedelta(1, "min")
 
     def __init__(self, calendars: set | abc.Sequence[xcals.ExchangeCalendar]):
         self._cals = calendars

--- a/src/market_prices/utils/pandas_utils.py
+++ b/src/market_prices/utils/pandas_utils.py
@@ -19,14 +19,13 @@ def pdfreq_to_offset(pdfreq: str) -> pd.offsets.BaseOffset:
     Parameters
     ----------
     pdfreq
-        pandas frequency string to convert. For example, '15min',
-            '15T', '3H'.
+        pandas frequency string to convert. For example, '15min', '3h'.
 
     Examples
     --------
-    >>> pdfreq_to_offset('22T')
+    >>> pdfreq_to_offset('22min')
     <22 * Minutes>
-    >>> pdfreq_to_offset('3H')
+    >>> pdfreq_to_offset('3h')
     <3 * Hours>
     >>> pdfreq_to_offset('3MS')
     <3 * MonthBegins>
@@ -93,7 +92,7 @@ def timestamps_in_interval_of_intervals(
 
     >>> intervals = pd.interval_range(start, end, freq="10D", closed=closed)
     >>> intervals
-    IntervalIndex([[2021-03-02, 2021-03-12], [2021-03-12, 2021-03-22]], dtype='interval[datetime64[ns], both]')
+    IntervalIndex([[2021-03-02 00:00:00, 2021-03-12 00:00:00], [2021-03-12 00:00:00, 2021-03-22 00:00:00]], dtype='interval[datetime64[ns], both]')
     >>> timestamps_in_interval_of_intervals(timestamps, intervals)
     True
     """
@@ -140,7 +139,7 @@ def make_non_overlapping(
 
     Examples
     --------
-    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1H')
+    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='h')
 
     >>> intervals = [
     ...     pd.Interval(left[0], left[0] + pd.Timedelta(45, 'min')),
@@ -213,7 +212,7 @@ def make_non_overlapping(
 
     # evaluate full_overlap_mask
     # as 'int64' to use expanding, as series to use expanding and shift
-    right = pd.Index(index.right.view("int64")).to_series()
+    right = pd.Index(index.right.astype("int64")).to_series()
     next_right = right.shift(-1)
     max_right_to_date = right.expanding().max()
     # shift 1 to move from overlapping indice to overlapped indice
@@ -257,7 +256,7 @@ def get_interval_index(
         interval.
 
     offset
-        Duration of each interval, for example "15min", "15T", "3H" etc.
+        Duration of each interval, for example "15min", "3h" etc.
 
     closed : default: "left"
         Side on which to close intervals.
@@ -272,8 +271,8 @@ def get_interval_index(
 
     Examples
     --------
-    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1H')
-    >>> index = get_interval_index(left, '33T')
+    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1h')
+    >>> index = get_interval_index(left, '33min')
     >>> index.to_series(index=range(5))
     0    [2021-05-01 12:00:00, 2021-05-01 12:33:00)
     1    [2021-05-01 13:00:00, 2021-05-01 13:33:00)
@@ -314,8 +313,8 @@ def interval_contains(interval: pd.Interval, intervals: pd.IntervalIndex) -> np.
 
     Examples
     --------
-    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1H')
-    >>> right = left + pd.Timedelta(30, 'T')
+    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1h')
+    >>> right = left + pd.Timedelta(30, 'min')
     >>> intervals = pd.IntervalIndex.from_arrays(left, right)
     >>> intervals.to_series(index=range(5))
     0    (2021-05-01 12:00:00, 2021-05-01 12:30:00]
@@ -389,8 +388,8 @@ def remove_intervals_from_interval(
     Examples
     --------
     >>> from pprint import pprint
-    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='1H')
-    >>> right = left + pd.Timedelta(30, 'T')
+    >>> left = pd.date_range('2021-05-01 12:00', periods=5, freq='h')
+    >>> right = left + pd.Timedelta(30, 'min')
     >>> intervals = pd.IntervalIndex.from_arrays(left, right)
     >>> intervals.to_series(index=range(5))
     0    (2021-05-01 12:00:00, 2021-05-01 12:30:00]
@@ -406,11 +405,11 @@ def remove_intervals_from_interval(
     ... )
     >>> rtrn = remove_intervals_from_interval(interval, intervals)
     >>> pprint(rtrn)
-    [Interval('2021-05-01 12:30:00', '2021-05-01 13:00:00', closed='left'),
-     Interval('2021-05-01 13:30:00', '2021-05-01 14:00:00', closed='left'),
-     Interval('2021-05-01 14:30:00', '2021-05-01 15:00:00', closed='left'),
-     Interval('2021-05-01 15:30:00', '2021-05-01 16:00:00', closed='left'),
-     Interval('2021-05-01 16:30:00', '2021-05-01 17:30:00', closed='left')]
+    [Interval(2021-05-01 12:30:00, 2021-05-01 13:00:00, closed='left'),
+     Interval(2021-05-01 13:30:00, 2021-05-01 14:00:00, closed='left'),
+     Interval(2021-05-01 14:30:00, 2021-05-01 15:00:00, closed='left'),
+     Interval(2021-05-01 15:30:00, 2021-05-01 16:00:00, closed='left'),
+     Interval(2021-05-01 16:30:00, 2021-05-01 17:30:00, closed='left')]
     """
     if not intervals.is_monotonic_increasing:
         raise ValueError(
@@ -502,9 +501,9 @@ def interval_index_new_tz(
     --------
     >>> tz = ZoneInfo("US/Central")
     >>> left = pd.date_range(
-    ...     '2021-05-01 12:00', periods=5, freq='1H', tz=tz
+    ...     '2021-05-01 12:00', periods=5, freq='h', tz=tz
     ... )
-    >>> right = left + pd.Timedelta(30, 'T')
+    >>> right = left + pd.Timedelta(30, 'min')
     >>> index = pd.IntervalIndex.from_arrays(left, right)
     >>> index.right.tz
     zoneinfo.ZoneInfo(key='US/Central')
@@ -537,7 +536,7 @@ def index_is_normalized(
 
     Examples
     --------
-    >>> index = pd.date_range('2021-05-01 12:00', periods=5, freq='1H')
+    >>> index = pd.date_range('2021-05-01 12:00', periods=5, freq='h')
     >>> index_is_normalized(index)
     False
     >>> index = pd.date_range('2021-05-01', periods=5, freq='1D')
@@ -545,7 +544,7 @@ def index_is_normalized(
     True
 
     >>> index = pd.interval_range(
-    ...     pd.Timestamp('2021-05-01 12:00'), periods=5, freq='1H'
+    ...     pd.Timestamp('2021-05-01 12:00'), periods=5, freq='h'
     ... )
     >>> index_is_normalized(index)
     False
@@ -577,8 +576,8 @@ def indexes_union(indexes: list[pd.Index]) -> pd.Index:
 
     Examples
     --------
-    >>> index1 = pd.date_range('2021-05-01 12:20', periods=2, freq='1H')
-    >>> index2 = pd.date_range('2021-05-02 17:10', periods=2, freq='22T')
+    >>> index1 = pd.date_range('2021-05-01 12:20', periods=2, freq='1h')
+    >>> index2 = pd.date_range('2021-05-02 17:10', periods=2, freq='22min')
     >>> index3 = pd.date_range('2021-05-03', periods=2, freq='1D')
     >>> indexes_union([index1, index2, index3])
     DatetimeIndex(['2021-05-01 12:20:00', '2021-05-01 13:20:00',
@@ -604,8 +603,8 @@ def index_union(indexes: list[Union[pd.Index, pd.Series, pd.DataFrame]]) -> pd.I
 
     Examples
     --------
-    >>> index1 = pd.date_range('2021-05-01 12:20', periods=2, freq='1H')
-    >>> index2 = pd.date_range('2021-05-02 17:10', periods=2, freq='22T')
+    >>> index1 = pd.date_range('2021-05-01 12:20', periods=2, freq='1h')
+    >>> index2 = pd.date_range('2021-05-02 17:10', periods=2, freq='22min')
     >>> index3 = pd.date_range('2021-05-03', periods=2, freq='1D')
     >>> ser = pd.Series(range(2), index=index2)
     >>> df = pd.DataFrame({'col_int': range(2)}, index=index3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,13 +144,13 @@ def one_day() -> abc.Iterator[pd.Timedelta]:
 @pytest.fixture(scope="session")
 def one_min() -> abc.Iterator[pd.Timedelta]:
     """pd.Timedelta with value as one minute."""
-    yield pd.Timedelta(1, "T")
+    yield pd.Timedelta(1, "min")
 
 
 @pytest.fixture(scope="session")
 def one_sec() -> abc.Iterator[pd.Timedelta]:
     """pd.Timedelta with value as one second."""
-    yield pd.Timedelta(1, "S")
+    yield pd.Timedelta(1, "s")
 
 
 _now_utc = pd.Timestamp("2021-11-17 21:59", tz=UTC)

--- a/tests/hypstrtgy.py
+++ b/tests/hypstrtgy.py
@@ -387,7 +387,7 @@ def pp_days_start_session(
     sessions = calendar.sessions
     limit_r = sessions[-pp["days"]]
     if start_will_roll_to_ms:
-        offset = pd.tseries.frequencies.to_offset("M")
+        offset = pd.tseries.frequencies.to_offset("ME")
         if TYPE_CHECKING:
             assert offset is not None
         limit_r = offset.rollback(limit_r)

--- a/tests/test_base_prices.py
+++ b/tests/test_base_prices.py
@@ -630,22 +630,22 @@ def prices_us_lon_hk(
 
 @pytest.fixture
 def session_length_xnys() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(6.5, "H")
+    yield pd.Timedelta(6.5, "h")
 
 
 @pytest.fixture
 def session_length_xhkg() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(6.5, "H")
+    yield pd.Timedelta(6.5, "h")
 
 
 @pytest.fixture
 def session_length_xlon() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(8.5, "H")
+    yield pd.Timedelta(8.5, "h")
 
 
 @pytest.fixture
 def session_length_bvmf() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(8, "H")
+    yield pd.Timedelta(8, "h")
 
 
 @pytest.fixture
@@ -1418,7 +1418,7 @@ class TestTableIntraday:
             table_H1, bi = f()
             assert bi is prices.bis.H1
             assert_interval(table_H1, prices.bis.H1)
-            assert_bounds(table_H1, (start, end_session_open + pd.Timedelta(1, "H")))
+            assert_bounds(table_H1, (start, end_session_open + pd.Timedelta(1, "h")))
 
     def test__get_bi_table_intraday_interval_non_bi(
         self, prices_us, stricts, priorities, one_min
@@ -1554,7 +1554,7 @@ class TestTableIntraday:
         assert_most_common_interval(table_T4_T1, ds_interval)
         assert table_T4_T1.pt.last_ts == end
         assert table_T4_T1.pt.first_ts in pd.date_range(
-            start=start, periods=4, freq="T"
+            start=start, periods=4, freq="min"
         )
 
         # verify prices unavailable if period extends beyond limit of availability
@@ -1582,7 +1582,7 @@ class TestTableIntraday:
         table = f()
         assert_most_common_interval(table, ds_interval)
         assert table.pt.last_ts == end - one_min
-        assert table.pt.first_ts in pd.date_range(start=start, periods=4, freq="T")
+        assert table.pt.first_ts in pd.date_range(start=start, periods=4, freq="min")
 
     def test__get_table_intraday_interval_H2(self, prices_us):
         """Test `_get_table_intraday` for H2 ds_interval.
@@ -1613,7 +1613,7 @@ class TestTableIntraday:
             )
             table = f()
             assert_bounds(table, (start, end_close))
-            assert table.index[-1].length == pd.Timedelta(30, "T")
+            assert table.index[-1].length == pd.Timedelta(30, "min")
             assert_most_common_interval(table, ds_interval)
 
             # verify when openend is MAINTAIN
@@ -1621,7 +1621,7 @@ class TestTableIntraday:
                 prices, pp, ds_interval, openend=OpenEnd.MAINTAIN
             )
             delta = 30 if ds_interval is prices.bis.H1 else 90
-            end_maintain = end_close + pd.Timedelta(delta, "T")
+            end_maintain = end_close + pd.Timedelta(delta, "min")
             table = f()
             assert_bounds(table, (start, end_maintain))
             assert_interval(table, ds_interval)
@@ -1639,7 +1639,7 @@ class TestTableIntraday:
         interval = prices.bis.T5
         range_start, _ = th.get_sessions_range_for_bi(prices, interval)
         _, range_end = th.get_sessions_range_for_bi(prices, prices.bis.T1)
-        length = pd.Timedelta(13, "H")
+        length = pd.Timedelta(13, "h")
         start, end = th.get_conforming_cc_sessions(
             prices.cc, length, range_start, range_end, 2
         )
@@ -1668,7 +1668,7 @@ class TestTableIntraday:
             # before close as nyse continues to trade after the close, hence to maintain
             # interval end on the last full interval prior to the close. Same effect for
             # H1 and H2.
-            end_maintain = end_close - pd.Timedelta(30, "T")
+            end_maintain = end_close - pd.Timedelta(30, "min")
             assert_bounds(table, (start_open, end_maintain))
             assert_interval(table, ds_interval)
 
@@ -1678,7 +1678,7 @@ class TestTableIntraday:
             )
             table = prices._get_table_intraday()
             assert_bounds(table, (start_open, end_close))
-            assert table.index[-1].length == pd.Timedelta(30, "T")
+            assert table.index[-1].length == pd.Timedelta(30, "min")
             assert_most_common_interval(table, ds_interval)
 
         # Verify for xnys lead
@@ -1705,7 +1705,7 @@ class TestTableIntraday:
             # 30/90 minutes although nothing trades after the close, hence maintains the
             # interval by extending the right of the last indice to beyond the close.
             delta = 30 if ds_interval is prices.bis.H1 else 90
-            end_maintain = end_close + pd.Timedelta(delta, "T")
+            end_maintain = end_close + pd.Timedelta(delta, "min")
             assert_bounds(table, (start_open, end_maintain))
             assert_interval(table, ds_interval)
 
@@ -1715,7 +1715,7 @@ class TestTableIntraday:
             )
             table = prices._get_table_intraday()
             assert_bounds(table, (start_open, end_close))
-            assert table.index[-1].length == pd.Timedelta(30, "T")
+            assert table.index[-1].length == pd.Timedelta(30, "min")
             assert_most_common_interval(table, ds_interval)
 
     def assertions_downsample_bi_table(
@@ -2224,7 +2224,7 @@ class TestGetComposite:
             prices, prices.bis.T1, calendars, session_length, 2
         )
         end_session_open = prices.cc.session_open(end_session)
-        end = end_session_open + pd.Timedelta(7, "T")
+        end = end_session_open + pd.Timedelta(7, "min")
         _, start_session = get_conforming_sessions(
             prices, prices.bis.T5, calendars, session_length, 2
         )
@@ -2239,9 +2239,9 @@ class TestGetComposite:
         assert table.pt.last_ts == end
 
         # Test edge case 1.
-        limit_T1_mock = end_session_open - pd.Timedelta(1, "H")
+        limit_T1_mock = end_session_open - pd.Timedelta(1, "h")
         prices = get_prices_limit_mock(prices, prices.bis.T1, limit_T1_mock)
-        end = end_session_open + pd.Timedelta(3, "T")
+        end = end_session_open + pd.Timedelta(3, "min")
         pp = get_pp(start=start_session, end=end)
         prices = set_get_prices_params(prices, pp, ds_interval=None, lead_symbol=lead)
         table_edgecase1 = prices._get_table_composite()
@@ -2250,9 +2250,9 @@ class TestGetComposite:
         assert_frame_equal(table_edgecase1[:-3], table[:-7])
 
         # Test edge case 2.
-        limit_T1_mock = end_session_open + pd.Timedelta(6, "T")
+        limit_T1_mock = end_session_open + pd.Timedelta(6, "min")
         prices = get_prices_limit_mock(prices, prices.bis.T1, limit_T1_mock)
-        end = end_session_open + pd.Timedelta(9, "T")
+        end = end_session_open + pd.Timedelta(9, "min")
         pp = get_pp(start=start_session, end=end)
         prices = set_get_prices_params(prices, pp, ds_interval=None, lead_symbol=lead)
         table_edgecase2 = prices._get_table_composite()
@@ -2268,9 +2268,9 @@ class TestGetComposite:
 
         # Verify raises error under edge case 2 when 'next table' has same interval
         # as table1.
-        limit_T1_mock = end_session_open + pd.Timedelta(20, "T")  # unable to serve
+        limit_T1_mock = end_session_open + pd.Timedelta(20, "min")  # unable to serve
         # T2 unable to serve from start of day
-        limit_T2_mock = end_session_open + pd.Timedelta(6, "T")
+        limit_T2_mock = end_session_open + pd.Timedelta(6, "min")
         limits = prices.BASE_LIMITS.copy()
         limits[prices.bis.T1] = limit_T1_mock
         limits[prices.bis.T2] = limit_T2_mock
@@ -2282,7 +2282,7 @@ class TestGetComposite:
 
         prices = PricesMock(symbols, prices._prices_tables, prices.lead_symbol_default)
 
-        end = end_session_open + pd.Timedelta(8, "T")
+        end = end_session_open + pd.Timedelta(8, "min")
         pp = get_pp(start=start_session, end=end)
         prices = set_get_prices_params(prices, pp, ds_interval=None, lead_symbol=lead)
 
@@ -2305,7 +2305,7 @@ class TestGetComposite:
         # set up as:
         # end avaialble from T2 data and can be reflected accurately by T2 data.
         # start available only for daily data.
-        length = pd.Timedelta(13, "H")
+        length = pd.Timedelta(13, "h")
         _start_session, end_session = get_sessions_daterange_for_bi(
             prices, prices.bis.T2, length_end_session=length
         )
@@ -2317,7 +2317,7 @@ class TestGetComposite:
                 raise ValueError(f"Unable to get a 'T2' session of length {length}.")
 
         end_session_open = prices.cc.session_open(end_session)
-        end = end_session_open + pd.Timedelta(6, "T")
+        end = end_session_open + pd.Timedelta(6, "min")
 
         start_H1, _ = get_sessions_daterange_for_bi(prices, prices.bis.H1)
         calendar = prices.calendars[lead]
@@ -2355,7 +2355,7 @@ class TestGetComposite:
 
         # Verify returns daily/intraday composite table under intraday/daily edge case
         # set up so that T2 availability starts between session open and period end.
-        limit_T2_mock = end_session_open + pd.Timedelta(1, "T")
+        limit_T2_mock = end_session_open + pd.Timedelta(1, "min")
         prices = get_prices_limit_mock(prices, prices.bis.T2, limit_T2_mock)
         pp = get_pp(start=start_session, end=end)
         prices = set_get_prices_params(prices, pp, ds_interval=None, lead_symbol=lead)
@@ -2386,7 +2386,7 @@ class TestGetComposite:
         calendar = prices.calendars[lead]
         end_session = calendar.session_offset(start_H1, -50)
         end_session_open = prices.cc.session_open(end_session)
-        end = end_session_open + pd.Timedelta(1, "H")
+        end = end_session_open + pd.Timedelta(1, "h")
         start_session = calendar.session_offset(end_session, -20)
 
         pp = get_pp(start=start_session, end=end)
@@ -2426,7 +2426,7 @@ class TestGet:
         assert not prices.has_data
 
         # verify options default values
-        prices.get("5T", minutes=30)
+        prices.get("5min", minutes=30)
         assert prices.has_data
         assert isinstance(prices.gpp, m.PricesBase.GetPricesParams)
         assert prices.gpp.anchor is Anchor.OPEN
@@ -2440,7 +2440,7 @@ class TestGet:
         lead = prices.lead_symbol_default
         strict = True
         prices.get(
-            "10T",
+            "10min",
             minutes=30,
             anchor="open",
             openend="maintain",
@@ -2459,7 +2459,7 @@ class TestGet:
         lead = get_symbols_for_calendar(prices, "XLON")
         strict = False
         prices.get(
-            "3T",
+            "3min",
             minutes=30,
             anchor="workback",
             openend="shorten",
@@ -2511,7 +2511,7 @@ class TestGet:
             " received 'wrkback'."
         )
         with pytest.raises(valimp.InputsError, match=msg):
-            prices.get("30T", anchor="wrkback")
+            prices.get("30min", anchor="wrkback")
 
         # verify period parameters being verified by `verify_period_parameters`
         msg = "If pass start and end then cannot pass a duration component."
@@ -2573,13 +2573,13 @@ class TestGet:
         # Verify return at intraday intervals.
 
         # verify end as time. Given end T5 is highest intraday interval that can fulfil.
-        end = cal.session_open(rng_end) + pd.Timedelta(5, "T")
+        end = cal.session_open(rng_end) + pd.Timedelta(5, "min")
         df = prices.get(start=rng_start, end=end)
         assertions_intraday_common(df, prices, prices.bis.T5)
         assert_bounds(df, (rng_start_open, end))
 
         # verify start as time.
-        start = cal.session_open(rng_start) + pd.Timedelta(5, "T")
+        start = cal.session_open(rng_start) + pd.Timedelta(5, "min")
         df = prices.get(start=start, end=rng_end)
         assertions_intraday_common(df, prices, prices.bis.H1)
         assert df.pt.first_ts == (rng_start_open + prices.bis.H1)
@@ -2593,14 +2593,14 @@ class TestGet:
         # verify minutes
         df = prices.get(start=rng_start, minutes=4)
         assertions_intraday_common(df, prices, prices.bis.T2)
-        assert_bounds(df, (rng_start_open, rng_start_open + pd.Timedelta(4, "T")))
+        assert_bounds(df, (rng_start_open, rng_start_open + pd.Timedelta(4, "min")))
         df = prices.get(minutes=4)
         assert df.pt.interval in (prices.bis.T1, prices.bis.T2)
 
         # verify hours
         df = prices.get(start=rng_start, hours=4)
         assertions_intraday_common(df, prices, prices.bis.H1)
-        assert_bounds(df, (rng_start_open, rng_start_open + pd.Timedelta(4, "H")))
+        assert_bounds(df, (rng_start_open, rng_start_open + pd.Timedelta(4, "h")))
         df = prices.get(start=rng_start, hours=50)
         assert df.pt.interval in prices.bis_intraday
 
@@ -2671,9 +2671,9 @@ class TestGet:
         f = prices.get
 
         # Verify raises PricesUnavailableIntervalDurationError
-        f("2H", hours=2, anchor="workback")
+        f("2h", hours=2, anchor="workback")
         with pytest.raises(errors.PricesUnavailableIntervalDurationError):
-            f("2H", hours=1, minutes=59)
+            f("2h", hours=1, minutes=59)
 
         # Verify raises PricesUnvailableDurationConflict (raised directly by `get``)
         match = (
@@ -2712,15 +2712,15 @@ class TestGet:
             f(session_length_xnys + one_min, **kwargs)
 
         # Verify raises PricesUnavailableIntervalPeriodError
-        start = cal.session_close(session) - pd.Timedelta(2, "T")
-        end = cal.session_open(cal.next_session(session)) + pd.Timedelta(2, "T")
+        start = cal.session_close(session) - pd.Timedelta(2, "min")
+        end = cal.session_open(cal.next_session(session)) + pd.Timedelta(2, "min")
         with pytest.raises(errors.PricesUnavailableIntervalPeriodError):
-            f("5T", start=start, end=end)
+            f("5min", start=start, end=end)
 
         start = cal.session_open(session) + prices.bis.T5
-        end = start + pd.Timedelta(4, "T")
+        end = start + pd.Timedelta(4, "min")
         with pytest.raises(errors.PricesUnavailableIntervalPeriodError):
-            f("5T", start=start, end=end)
+            f("5min", start=start, end=end)
 
     def test_interval_only_param(self, prices_us, one_day, one_min):
         """Test passing interval as only parameter.
@@ -2738,7 +2738,7 @@ class TestGet:
             last_to = cal.minute_to_trading_minute(limit_right, "previous")
             last_from = cal.minute_offset_by_sessions(last_to, -1)
             if bi is prices.bis.H1:
-                last_to += pd.Timedelta(30, "T")  # provide for possibly unaligned end
+                last_to += pd.Timedelta(30, "min")  # provide for possibly unaligned end
             df = f(bi)
             assert first_from <= df.pt.first_ts <= first_to
             # + one_min to cover processing between evaluating last_to and evaluating df
@@ -2786,7 +2786,7 @@ class TestGet:
         """
         prices = prices_247
         with pytest.warns(errors.IntervalIrregularWarning):
-            df = prices.get("7T", days=2)
+            df = prices.get("7min", days=2)
         assert_most_common_interval(df, intervals.TDInterval.T7)
 
     def test_intervals_overlapping_with_break(self, prices_with_break, one_min):
@@ -2833,7 +2833,7 @@ class TestGet:
         start_dt = datetime.datetime(sl.year, sl.month, sl.day, sl.hour, sl.minute)
 
         end = cal.session_close(session)
-        end -= pd.Timedelta(30, "T")
+        end -= pd.Timedelta(30, "min")
         end_utc = end
         end_local = el = end.astimezone(prices.tz_default)
         end_str = el.strftime("%Y-%m-%d %H:%M")
@@ -2844,15 +2844,15 @@ class TestGet:
         starts = (start_utc, start_local, start_str, start_str2, start_int, start_dt)
         ends = (end_utc, end_local, end_str, end_str2, end_int, end_dt)
 
-        df_base = prices.get("2H", starts[0], ends[0])
+        df_base = prices.get("2h", starts[0], ends[0])
         for start, end in zip(starts[1:], ends[1:]):
-            df = prices.get("2H", start, end)
+            df = prices.get("2h", start, end)
             assert_frame_equal(df, df_base)
 
         # Verify `tzin`
         symb_xnys = get_symbols_for_calendar(prices, "XNYS")
         for tzin in ("America/New_York", ZoneInfo("America/New_York"), symb_xnys):
-            df = prices.get("2H", start_utc, end_str, tzin=tzin)
+            df = prices.get("2h", start_utc, end_str, tzin=tzin)
             assert_frame_equal(df, df_base)
 
         # verify can pass as non-default symbol
@@ -2862,7 +2862,7 @@ class TestGet:
         end_lon_tz = end_utc.astimezone(prices.timezones[symb_xlon])
         end_lon_str = end_lon_tz.strftime("%Y-%m-%d %H:%M")
         df = prices.get(
-            "2H", start_lon_str, end_lon_str, tzin=symb_xlon, tzout=symb_xnys
+            "2h", start_lon_str, end_lon_str, tzin=symb_xlon, tzout=symb_xnys
         )
         assert_frame_equal(df, df_base)
 
@@ -2896,7 +2896,7 @@ class TestGet:
 
         # verify returning intaday data, also verifies can pass `start` and `end`
         # as positional arguments
-        df = prices.get("5T", start_session, end_session)
+        df = prices.get("5min", start_session, end_session)
         start = cal.session_open(start_session)
         end = cal.session_close(end_session)
         num_rows = int((session_length_xnys / prices.bis.T5)) * num_sessions
@@ -2922,33 +2922,33 @@ class TestGet:
         )
 
         # verify return of intraday data.
-        df = prices.get("10T", start, end)
+        df = prices.get("10min", start, end)
         assertions_intraday(df, TDInterval.T10, prices, start, end, num_rows // 2)
-        df = prices.get("5T", start, end)
+        df = prices.get("5min", start, end)
         assertions_intraday(df, TDInterval.T5, prices, start, end, num_rows)
 
         # verify passing `start` and `end` as non-trading times
-        assert_frame_equal(df, prices.get("5T", start - one_min, end + one_min))
-        delta = pd.Timedelta(45, "T")
-        assert_frame_equal(df, prices.get("5T", start - delta, end + delta))
+        assert_frame_equal(df, prices.get("5min", start - one_min, end + one_min))
+        delta = pd.Timedelta(45, "min")
+        assert_frame_equal(df, prices.get("5min", start - delta, end + delta))
 
         # verify passing `start` and `end` 6 min inside session bounds knocks 2 indices
         # off each end
-        delta = pd.Timedelta(6, "T")
-        assert_frame_equal(df[2:-2], prices.get("5T", start + delta, end - delta))
+        delta = pd.Timedelta(6, "min")
+        assert_frame_equal(df[2:-2], prices.get("5min", start + delta, end - delta))
 
         # verify just one second inside the session bounds will knock off the
         # first/last indices
-        assert_frame_equal(df[1:-1], prices.get("5T", start + one_sec, end - one_sec))
+        assert_frame_equal(df[1:-1], prices.get("5min", start + one_sec, end - one_sec))
 
         # Verify passing `start` and `end` as mix of data and time
         assert_frame_equal(df_daily, prices.get("1D", start_session, end))
         assert_frame_equal(df_daily, prices.get("1D", start, end_session))
         assert_frame_equal(df_daily[1:], prices.get("1D", start + one_sec, end_session))
 
-        assert_frame_equal(df, prices.get("5T", start_session, end))
-        assert_frame_equal(df[:-1], prices.get("5T", start_session, end - one_sec))
-        assert_frame_equal(df, prices.get("5T", start, end_session))
+        assert_frame_equal(df, prices.get("5min", start_session, end))
+        assert_frame_equal(df[:-1], prices.get("5min", start_session, end - one_sec))
+        assert_frame_equal(df, prices.get("5min", start, end_session))
 
     def test_start_end_none_bi(self, prices_us):
         """Test `start` and `end` as None and intervals as base intervals."""
@@ -3002,31 +3002,33 @@ class TestGet:
         # getting intraday data
         open_ = cal.session_open(start_session)
         close = cal.session_close(end_session)
-        num_rows = int((session_length_xnys * num_sessions) / pd.Timedelta(30, "T"))
-        df = prices.get("30T", start=start_session, days=num_sessions)
+        num_rows = int((session_length_xnys * num_sessions) / pd.Timedelta(30, "min"))
+        df = prices.get("30min", start=start_session, days=num_sessions)
         assertions_intraday(df, TDInterval.T30, prices, open_, close, num_rows)
-        assert_frame_equal(df, prices.get("30T", end=end_session, days=num_sessions))
+        assert_frame_equal(df, prices.get("30min", end=end_session, days=num_sessions))
 
         # verify to bound as time
         # getting intraday data
-        start = open_ + pd.Timedelta(88, "T")
-        df_intra = prices.get("30T", start, days=num_sessions - 1)
-        exp_start = open_ + pd.Timedelta(90, "T")
-        exp_end = cal.session_open(end_session) + pd.Timedelta(90, "T")
+        start = open_ + pd.Timedelta(88, "min")
+        df_intra = prices.get("30min", start, days=num_sessions - 1)
+        exp_start = open_ + pd.Timedelta(90, "min")
+        exp_end = cal.session_open(end_session) + pd.Timedelta(90, "min")
         num_rows -= 13
         if exp_start.time() != exp_end.time():
             # adjust for different DST observance
             if exp_end.time() > exp_start.time():
-                exp_end -= pd.Timedelta(1, "H")
+                exp_end -= pd.Timedelta(1, "h")
                 num_rows -= 2
             else:
-                exp_end += pd.Timedelta(1, "H")
+                exp_end += pd.Timedelta(1, "h")
                 num_rows += 2
         assertions_intraday(
             df_intra, TDInterval.T30, prices, exp_start, exp_end, num_rows
         )
         end = exp_end + one_min  # verify aligning as expected
-        assert_frame_equal(df_intra, prices.get("30T", end=end, days=num_sessions - 1))
+        assert_frame_equal(
+            df_intra, prices.get("30min", end=end, days=num_sessions - 1)
+        )
         # getting daily data
         df = prices.get("1D", start, days=num_sessions - 1)
         assertions_daily(df, prices, sessions[1], end_session)
@@ -3036,11 +3038,11 @@ class TestGet:
         # verify to now as trading time
         # one sec short of 30 min post last session open
         mock_now(monkeypatch, exp_end - one_sec)
-        df = prices.get("30T", days=num_sessions - 1)
+        df = prices.get("30min", days=num_sessions - 1)
         assert_frame_equal(df_intra, df)
 
         # verify to now as non-trading time
-        mock_now(monkeypatch, close + pd.Timedelta(2, "H"))
+        mock_now(monkeypatch, close + pd.Timedelta(2, "h"))
         assert_frame_equal(
             df_daily, prices.get("D", end=end_session, days=num_sessions)
         )
@@ -3071,26 +3073,26 @@ class TestGet:
 
         # verify getting intraday data with bound as date
         end_session = cal.session_offset(start_session, num_sessions_in_week - 1)
-        df = prices.get("30T", start_session, weeks=1)
+        df = prices.get("30min", start_session, weeks=1)
         # Verifications piggy backs on separate testing of durations in terms of
         # trading sessions
-        expected = prices.get("30T", start_session, days=num_sessions_in_week)
+        expected = prices.get("30min", start_session, days=num_sessions_in_week)
         assert_frame_equal(df, expected)
-        expected = prices.get("30T", end=end_session, days=num_sessions_in_week)
+        expected = prices.get("30min", end=end_session, days=num_sessions_in_week)
         assert_frame_equal(df, expected)
 
         # verify getting intraday data with bound as time
         # end_session will now be one session later
         end_session2 = cal.session_offset(start_session, num_sessions_in_week)
         open_ = cal.session_open(start_session)
-        start = open_ + pd.Timedelta(28, "T")
-        df = prices.get("30T", start, weeks=1)
+        start = open_ + pd.Timedelta(28, "min")
+        df = prices.get("30min", start, weeks=1)
         # Verification piggy backs on separate testing of durations in terms of
         # trading sessions
-        expected = prices.get("30T", start, days=num_sessions_in_week)
+        expected = prices.get("30min", start, days=num_sessions_in_week)
         assert_frame_equal(df, expected)
-        end = cal.session_open(end_session2) + pd.Timedelta(32, "T")
-        df_intra = prices.get("30T", end=end, weeks=1)
+        end = cal.session_open(end_session2) + pd.Timedelta(32, "min")
+        df_intra = prices.get("30min", end=end, weeks=1)
         assert_frame_equal(df_intra, expected)
 
         # verify getting daily data
@@ -3113,14 +3115,14 @@ class TestGet:
         assertions_monthly(df, prices, None, first_exp, last_exp)
 
         # verify to now as trading time
-        now = cal.session_open(end_session2) + pd.Timedelta(30, "T") - one_sec
+        now = cal.session_open(end_session2) + pd.Timedelta(30, "min") - one_sec
         # one sec short of 30 min post last session open
         mock_now(monkeypatch, now - one_sec)
-        df = prices.get("30T", weeks=1)
+        df = prices.get("30min", weeks=1)
         assert_frame_equal(df_intra, df)
 
         # verify to now as non-trading time
-        mock_now(monkeypatch, cal.session_open(end_session) + pd.Timedelta(2, "H"))
+        mock_now(monkeypatch, cal.session_open(end_session) + pd.Timedelta(2, "h"))
         assert_frame_equal(df_daily, prices.get("D", weeks=1), check_freq=False)
 
     def test_trading_time_duration(self, prices_us, monkeypatch):
@@ -3132,55 +3134,55 @@ class TestGet:
         prev_session, session = get_consecutive_sessions(prices, prices.bis.T1, cal)
 
         # verify bounds with a session
-        df = prices.get("5T", session, minutes=20)
+        df = prices.get("5min", session, minutes=20)
         open_, close = cal.session_open_close(session)
         assertions_intraday(
-            df, TDInterval.T5, prices, open_, open_ + pd.Timedelta(20, "T"), 4
+            df, TDInterval.T5, prices, open_, open_ + pd.Timedelta(20, "min"), 4
         )
 
-        df = prices.get("15T", end=session, hours=1)
+        df = prices.get("15min", end=session, hours=1)
         assertions_intraday(
-            df, TDInterval.T15, prices, close - pd.Timedelta(1, "H"), close, 4
+            df, TDInterval.T15, prices, close - pd.Timedelta(1, "h"), close, 4
         )
 
         # verify bounds with a time
-        bound = open_ + pd.Timedelta(30, "T")
-        df = prices.get("15T", bound, hours=1, minutes=15)
+        bound = open_ + pd.Timedelta(30, "min")
+        df = prices.get("15min", bound, hours=1, minutes=15)
         delta = pd.Timedelta(hours=1, minutes=15)
         assertions_intraday(df, TDInterval.T15, prices, bound, bound + delta, 5)
 
         # verify crossing sessions
-        df = prices.get("15T", end=bound, hours=1, minutes=15)
+        df = prices.get("15min", end=bound, hours=1, minutes=15)
         prev_close = cal.session_close(prev_session)
-        exp_start = prev_close - pd.Timedelta(45, "T")
+        exp_start = prev_close - pd.Timedelta(45, "min")
         assertions_intraday(df, TDInterval.T15, prices, exp_start, bound, 5)
 
         # verify Silver Rule (if bound unaligned then start from next aligned indice)
-        df = prices.get("25T", start=bound, hours=1, minutes=40)
-        exp_start = bound + pd.Timedelta(20, "T")
+        df = prices.get("25min", start=bound, hours=1, minutes=40)
+        exp_start = bound + pd.Timedelta(20, "min")
         exp_end = exp_start + pd.Timedelta(hours=1, minutes=40)
         assertions_intraday(df, TDInterval.T25, prices, exp_start, exp_end, 4)
 
         # verify limit before next indice would be included
-        assert_frame_equal(df, prices.get("25T", start=bound, hours=2, minutes=4))
-        df = prices.get("25T", start=bound, hours=2, minutes=5)
-        exp_end += pd.Timedelta(25, "T")
+        assert_frame_equal(df, prices.get("25min", start=bound, hours=2, minutes=4))
+        df = prices.get("25min", start=bound, hours=2, minutes=5)
+        exp_end += pd.Timedelta(25, "min")
         assertions_intraday(df, TDInterval.T25, prices, exp_start, exp_end, 5)
 
         # verify default end with now as trading time
-        now = open_ + pd.Timedelta(32, "T")
+        now = open_ + pd.Timedelta(32, "min")
         mock_now(monkeypatch, now)
-        df = prices.get("5T", minutes=20)
-        exp_end = open_ + pd.Timedelta(35, "T")
-        exp_start = exp_end - pd.Timedelta(20, "T")
+        df = prices.get("5min", minutes=20)
+        exp_end = open_ + pd.Timedelta(35, "min")
+        exp_start = exp_end - pd.Timedelta(20, "min")
         assertions_intraday(df, TDInterval.T5, prices, exp_start, exp_end, 4)
 
         # verify default end with now as non-trading time
-        now = close + pd.Timedelta(2, "H")
+        now = close + pd.Timedelta(2, "h")
         mock_now(monkeypatch, now)
-        df = prices.get("2T", minutes=41)
+        df = prices.get("2min", minutes=41)
         assertions_intraday(
-            df, TDInterval.T2, prices, close - pd.Timedelta(40, "T"), close, 20
+            df, TDInterval.T2, prices, close - pd.Timedelta(40, "min"), close, 20
         )
 
     def test_lead_symbol(self, prices_us_lon, session_length_xnys, session_length_xlon):
@@ -3210,11 +3212,11 @@ class TestGet:
 
         # start as one hour prior to XNYS open
         xnys_open = xnys.session_open(session)
-        start = xnys_open - pd.Timedelta(1, "H")
-        args, kwargs = ("6T", start), {"minutes": 30}
+        start = xnys_open - pd.Timedelta(1, "h")
+        args, kwargs = ("6min", start), {"minutes": 30}
         # verify start rolls forward to XNYS open
         df = prices.get(*args, **kwargs, lead_symbol=symb_xnys)
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
         assertions_intraday(
             df, TDInterval.T6, prices, xnys_open, xnys_open + half_hour, 5
         )
@@ -3241,15 +3243,15 @@ class TestGet:
         # verify for intraday interval, with add_a_row causing cross in sessions
         _, session = get_consecutive_sessions(prices, prices.bis.T1, cal)
         start = cal.session_open(session)
-        args = ("10T", start)
+        args = ("10min", start)
         kwargs = {"minutes": 30}
         base_df = prices.get(*args, **kwargs)
-        exp_end = start + pd.Timedelta(30, "T")
+        exp_end = start + pd.Timedelta(30, "min")
         assertions_intraday(base_df, TDInterval.T10, prices, start, exp_end, 3)
 
         df = prices.get(*args, **kwargs, add_a_row=True)
         assert_frame_equal(df[1:], base_df, check_freq=False)
-        exp_start = cal.previous_close(start) - pd.Timedelta(10, "T")
+        exp_start = cal.previous_close(start) - pd.Timedelta(10, "min")
         assertions_intraday(df, TDInterval.T10, prices, exp_start, exp_end, 4)
 
     # ---------------------- Tests related to anchor ----------------------
@@ -3293,7 +3295,7 @@ class TestGet:
         start_session, end_session = get_conforming_sessions(
             prices, prices.bis.T1, [xnys], [session_length_xnys], 2
         )
-        df = prices.get("30T", start_session, end_session, anchor="open", tzout=UTC)
+        df = prices.get("30min", start_session, end_session, anchor="open", tzout=UTC)
         assert df.pt.has_regular_interval
         assert df.pt.indices_have_regular_trading_minutes(xnys)
 
@@ -3308,11 +3310,11 @@ class TestGet:
         assert_index_equal(df.index, exp_index)
 
         # verify when unaligned with session close
-        df = prices.get("90T", start_session, end_session, anchor="open", tzout=UTC)
+        df = prices.get("90min", start_session, end_session, anchor="open", tzout=UTC)
         assert df.pt.has_regular_interval
         assert not df.pt.indices_have_regular_trading_minutes(xnys)
 
-        misalignment = pd.Timedelta(1, "H")
+        misalignment = pd.Timedelta(1, "h")
         start = xnys.session_open(start_session)
         end_start_session = xnys.session_close(start_session) + misalignment
         start_end_session = xnys.session_open(end_session)
@@ -3340,7 +3342,7 @@ class TestGet:
             prices, prices.bis.T1, [xhkg], [session_length_xhkg], 2
         )
 
-        df = prices.get("30T", start_session, end_session, anchor="open", tzout=UTC)
+        df = prices.get("30min", start_session, end_session, anchor="open", tzout=UTC)
         assert df.pt.has_regular_interval
         assert df.pt.indices_have_regular_trading_minutes(xhkg)
 
@@ -3355,25 +3357,25 @@ class TestGet:
         assert_index_equal(df.index, exp_index)
 
         # verify when unaligned with both am and pm subsession closes
-        df = prices.get("40T", start_session, end_session, anchor="open", tzout=UTC)
+        df = prices.get("40min", start_session, end_session, anchor="open", tzout=UTC)
         assert df.pt.has_regular_interval
         assert not df.pt.indices_have_regular_trading_minutes(xhkg)
 
         starts, ends = [], []
         for session in (start_session, end_session):
             starts.append(xhkg.session_open(session))
-            ends.append(xhkg.session_break_start(session) + pd.Timedelta(10, "T"))
+            ends.append(xhkg.session_break_start(session) + pd.Timedelta(10, "min"))
             starts.append(xhkg.session_break_end(session))
-            ends.append(xhkg.session_close(session) + pd.Timedelta(20, "T"))
+            ends.append(xhkg.session_close(session) + pd.Timedelta(20, "min"))
         interval = TDInterval.T40
         exp_index = self.create_index(starts, ends, interval)
         assert_index_equal(df.index, exp_index)
 
         # # verify to now includes live indice and nothing beyond
-        now = ends[-1] - pd.Timedelta(50, "T")
+        now = ends[-1] - pd.Timedelta(50, "min")
         mock_now(monkeypatch, now)
         # should lose last indice
-        df_ = prices.get("40T", start_session, end_session, anchor="open", tzout=UTC)
+        df_ = prices.get("40min", start_session, end_session, anchor="open", tzout=UTC)
         # last indice be the same although not values as now is 10 minutes short
         # of the full indice
         assert_frame_equal(df_[:-1], df[:-2])
@@ -3392,7 +3394,9 @@ class TestGet:
             prices, prices.bis.T1, [xnys], [session_length_xnys], 2
         )
 
-        df = prices.get("90T", start_session, end_session, anchor="workback", tzout=UTC)
+        df = prices.get(
+            "90min", start_session, end_session, anchor="workback", tzout=UTC
+        )
         assert len(df.pt.indices_length) == 2
         assert len(df.pt.indices_partial_trading(xnys)) == 1
         assert df.pt.indices_have_regular_trading_minutes(xnys)
@@ -3402,7 +3406,7 @@ class TestGet:
         start = end - (interval * 4)
         index_end = self.create_single_index(start, end, interval)
 
-        end = xnys.session_close(start_session) - pd.Timedelta(1, "H")
+        end = xnys.session_close(start_session) - pd.Timedelta(1, "h")
         start = end - (interval * 3)
         index_start = self.create_single_index(start, end, interval)
 
@@ -3415,8 +3419,8 @@ class TestGet:
         assert_index_equal(df.index, index)
 
         # Verify to specific minute
-        end = xnys.session_close(start_session) - pd.Timedelta(43, "T")
-        df = prices.get("30T", end=end, hours=4, anchor="workback", tzout=UTC)
+        end = xnys.session_close(start_session) - pd.Timedelta(43, "min")
+        df = prices.get("30min", end=end, hours=4, anchor="workback", tzout=UTC)
         interval = TDInterval.T30
         start = end - (8 * interval)
         index = self.create_single_index(start, end, interval)
@@ -3425,7 +3429,7 @@ class TestGet:
         # Verify to now
         mock_now(monkeypatch, end - one_min)
         prices = reset_prices(prices)
-        df_ = prices.get("30T", hours=4, anchor="workback", tzout=UTC)
+        df_ = prices.get("30min", hours=4, anchor="workback", tzout=UTC)
         assert_frame_equal(df_, df)
 
     def test_workback_indices_with_break(self, prices_with_break, session_length_xhkg):
@@ -3440,7 +3444,7 @@ class TestGet:
             prices, prices.bis.T1, [xhkg], [session_length_xhkg], 1
         )[0]
 
-        df = prices.get("40T", session, session, anchor="workback", tzout=UTC)
+        df = prices.get("40min", session, session, anchor="workback", tzout=UTC)
         assert len(df.pt.indices_length) == 2
         assert len(df.pt.indices_partial_trading(xhkg)) == 1
         assert df.pt.indices_have_regular_trading_minutes(xhkg)
@@ -3450,7 +3454,7 @@ class TestGet:
         start = end - (interval * 4)
         index_end = self.create_single_index(start, end, interval)
 
-        end = xhkg.session_break_start(session) - pd.Timedelta(20, "T")
+        end = xhkg.session_break_start(session) - pd.Timedelta(20, "min")
         start = end - (interval * 3)
         index_start = self.create_single_index(start, end, interval)
 
@@ -3477,13 +3481,13 @@ class TestGet:
         start_session, end_session = get_sessions_xnys_xhkg_xlon(prices.bis.T1, 2)
 
         kwargs = {
-            "interval": "1H",
+            "interval": "1h",
             "start": start_session,
             "end": end_session,
             "tzout": UTC,
         }
         interval = TDInterval.H1
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
 
         # Verify for indices anchored "open" with xlon as lead cal
         df = prices.get(**kwargs, anchor="open", lead_symbol=xlon_symb)
@@ -3568,7 +3572,7 @@ class TestGet:
         )[0]
 
         # verify not forced
-        df = prices.get("40T", session, session, anchor="open", force=False)
+        df = prices.get("40min", session, session, anchor="open", force=False)
         assert df.pt.has_regular_interval
         assert xhkg.session_break_start(session) not in df.index.right
         assert df.pt.last_ts != xhkg.session_close(session)
@@ -3576,11 +3580,11 @@ class TestGet:
         assert len(df.pt.indices_partial_trading(xhkg)) == 2
 
         # verify not forced by default
-        df_ = prices.get("40T", session, session, anchor="open")
+        df_ = prices.get("40min", session, session, anchor="open")
         assert_frame_equal(df_, df)
 
         # verify forced
-        df_f = prices.get("40T", session, session, anchor="open", force=True)
+        df_f = prices.get("40min", session, session, anchor="open", force=True)
         assert not df_f.pt.has_regular_interval
         assert xhkg.session_break_start(session) in df_f.index.right
         assert df_f.pt.last_ts == xhkg.session_close(session)
@@ -3603,7 +3607,7 @@ class TestGet:
         start_session_close = x247.session_close(start_session)
         end_session_open = x247.session_open(end_session)
         assert start_session_close == end_session_open
-        df = prices.get("8H", start_session, end_session, anchor="open")
+        df = prices.get("8h", start_session, end_session, anchor="open")
         assert df.pt.has_regular_interval
         assert len(df.pt.indices_length) == 1
         assert start_session_close in df.index.left
@@ -3611,7 +3615,7 @@ class TestGet:
 
         # verify warns
         with pytest.warns(errors.IntervalIrregularWarning):
-            df = prices.get("7H", start_session, end_session, anchor="open")
+            df = prices.get("7h", start_session, end_session, anchor="open")
         assert not df.pt.has_regular_interval
         assert len(df.pt.indices_length) == 2
         assert start_session_close in df.index.left
@@ -3630,7 +3634,7 @@ class TestGet:
         )[0]
 
         # verify am/pm indices do not overlap on limit
-        df = prices.get("105T", session, session, anchor="open")
+        df = prices.get("105min", session, session, anchor="open")
         assert df.pt.has_regular_interval
         assert len(df.pt.indices_length) == 1
         assert xhkg.session_break_end(session) in df.index.left
@@ -3638,7 +3642,7 @@ class TestGet:
 
         # verify warns
         with pytest.warns(errors.IntervalIrregularWarning):
-            df = prices.get("106T", session, session, anchor="open")
+            df = prices.get("106min", session, session, anchor="open")
         assert not df.pt.has_regular_interval
         assert len(df.pt.indices_length) == 2
         assert xhkg.session_break_end(session) in df.index.left
@@ -3661,12 +3665,12 @@ class TestGet:
             prices, interval, [xhkg], [session_length_xhkg], 1
         )[0]
 
-        df = prices.get("1H", session, session, anchor="open", tzout=UTC)
+        df = prices.get("1h", session, session, anchor="open", tzout=UTC)
         assert df.pt.has_regular_interval
         assert (df.index.left.minute == 30).all()
         assert (df.index.right.minute == 30).all()
         start = xhkg.session_open(session)
-        end = xhkg.session_close(session) + pd.Timedelta(30, "T")
+        end = xhkg.session_close(session) + pd.Timedelta(30, "min")
         index = self.create_single_index(start, end, interval)
         assert_index_equal(df.index, index)
 
@@ -3682,7 +3686,7 @@ class TestGet:
         start_session, end_session = get_sessions_xnys_xhkg_xlon(prices.bis.T1, 2)
         interval = TDInterval.T50
 
-        df = prices.get("50T", start_session, end_session, anchor="open", tzout=UTC)
+        df = prices.get("50min", start_session, end_session, anchor="open", tzout=UTC)
         df = df[:9]  # only take what's necessary to prove the point
         assert df.pt.last_ts > xhkg.session_break_end(start_session)
         starts, ends = [], []
@@ -3711,18 +3715,18 @@ class TestGet:
         start, end = xnys.session_open_close(session)
 
         # verify maintain when no symbol trades after unaligned close
-        df = prices.get("1H", start, end, openend="maintain")
+        df = prices.get("1h", start, end, openend="maintain")
         assert df.pt.has_regular_interval
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
         exp_end = end + half_hour
         assertions_intraday(df, prices.bis.H1, prices, start, exp_end, 7)
 
         # verify maintain is default
-        df_ = prices.get("1H", start, end)
+        df_ = prices.get("1h", start, end)
         assert_frame_equal(df, df_)
 
         # verify shorten
-        df = prices.get("1H", start, end, openend="shorten")
+        df = prices.get("1h", start, end, openend="shorten")
         assert not df.pt.has_regular_interval
         last_indice = df.index[-1]
         assert last_indice.right == end
@@ -3749,14 +3753,14 @@ class TestGet:
         start, end = xlon.session_open_close(session)
 
         # verify maintain when symbol trades after unaligned close
-        df = prices.get("1H", start, end, openend="maintain")
+        df = prices.get("1h", start, end, openend="maintain")
         assert df.pt.has_regular_interval
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
         exp_end = end - half_hour
         assertions_intraday(df, prices.bis.H1, prices, start, exp_end, 8)
 
         # verify shorten
-        df = prices.get("1H", start, end, openend="shorten")
+        df = prices.get("1h", start, end, openend="shorten")
         assert not df.pt.has_regular_interval
         last_indice = df.index[-1]
         assert last_indice.right == end
@@ -3771,7 +3775,7 @@ class TestGet:
             prices, prices.bis.H1, [xlon], [session_length_xlon], 1
         )[0]
         start, end = xlon.session_open_close(session)
-        df = prices.get("1H", start, end, openend="shorten")
+        df = prices.get("1h", start, end, openend="shorten")
         assert df.pt.has_regular_interval
         exp_end = end - half_hour
         assertions_intraday(df, prices.bis.H1, prices, start, exp_end, 8)
@@ -3999,7 +4003,7 @@ class TestGet:
 
         # verify when single interval would have comprise minutes from both end of
         # previous session and start of session
-        delta = pd.Timedelta(2, "T")
+        delta = pd.Timedelta(2, "min")
         start = prev_session_close - bi + delta
         end = session_open + delta
 
@@ -4020,7 +4024,7 @@ class TestGet:
         session_open = cal.session_open(session)
         prev_session_close = cal.session_close(prev_session)
 
-        delta = pd.Timedelta(2, "T")
+        delta = pd.Timedelta(2, "min")
         start = prev_session_close - bi + delta
         end = session_open + delta
 
@@ -4083,7 +4087,7 @@ class TestGet:
                 prices.get(bi, start, minutes=4, anchor=anchor)
                 prices.get(dsi, start, minutes=14, anchor=anchor)
 
-        delta = pd.Timedelta(2, "T")
+        delta = pd.Timedelta(2, "min")
         end = session_open_T1 + delta
 
         anchor = "workback"
@@ -4127,9 +4131,9 @@ class TestGet:
         # Test effect of strict on error raised
         l_limit = prices.limits[prices.bis.T5][0]
         l_limit = cal.minute_to_trading_minute(l_limit, "next")
-        end = l_limit + pd.Timedelta(2, "H")
+        end = l_limit + pd.Timedelta(2, "h")
         # error depends on strict
-        get_kwargs = dict(interval="3H", end=end, hours=6, anchor="workback")
+        get_kwargs = dict(interval="3h", end=end, hours=6, anchor="workback")
         with pytest.raises(errors.PricesIntradayUnavailableError):
             prices.get(**get_kwargs, strict=True)
         with pytest.raises(errors.PricesUnavailableIntervalPeriodError):
@@ -4159,7 +4163,7 @@ class TestGet:
                     errors.PricesIntradayUnavailableError, match=msg_pass_strict
                 ):
                     prices.get(
-                        "3T",
+                        "3min",
                         session_T5,
                         session_T5,
                         strict=strict,
@@ -4173,10 +4177,10 @@ class TestGet:
         ):
             # `priority` should make no difference
             for priority in priorities:
-                prices.get("3T", session_T5, priority=priority)
+                prices.get("3min", session_T5, priority=priority)
 
         # although returns data from limit if strict False
-        df = prices.get("3T", session_T5, strict=False)
+        df = prices.get("3min", session_T5, strict=False)
         assert df.pt.first_ts >= prices.limits[prices.bis.T1][0] - one_min
         assert df.pt.interval == TDInterval.T3
 
@@ -4196,7 +4200,7 @@ class TestGet:
         limit_H1 = prices.limits[prices.bis.H1][0]
 
         # period end that can only be represented with T1 or T5 data
-        end = xnys.session_close(end_T1) - pd.Timedelta(15, "T")
+        end = xnys.session_close(end_T1) - pd.Timedelta(15, "min")
 
         # verify data available if requested period falls within bounds of
         # available T5 data
@@ -4242,29 +4246,31 @@ class TestGet:
         # given the data that's available.
         # set end to time that can only be represented by T1, although for which
         # smallest interval for which data is available is T5
-        end = xnys.session_close(start_T5) - pd.Timedelta(3, "T")
+        end = xnys.session_close(start_T5) - pd.Timedelta(3, "min")
         df = prices.get(start=start_T5, end=end)
         assert df.pt.interval == prices.bis.T5
-        assert df.pt.last_ts == end - pd.Timedelta(2, "T")
+        assert df.pt.last_ts == end - pd.Timedelta(2, "min")
 
         # verify error not raised when interval passed and anchor "open",
         # regardless of final indice not representing period end
-        df_ = prices.get("5T", start=start_T5, end=end)
+        df_ = prices.get("5min", start=start_T5, end=end)
         assert_frame_equal(df, df_)
 
         # verify that raises errors when anchor="workback"
         # set period such that T1 data only available over period end and
         # period end can only be served with T1 data.
-        end = xnys.session_close(start_T1) - pd.Timedelta(3, "T")
+        end = xnys.session_close(start_T1) - pd.Timedelta(3, "min")
         # whilst prices available when anchor "open"
-        df = prices.get("10T", start=start_T5, end=end, anchor="open")
+        df = prices.get("10min", start=start_T5, end=end, anchor="open")
         assert df.pt.interval == TDInterval.T10
         # verify not when anchor is "workback"
         with pytest.raises(errors.LastIndiceInaccurateError):
-            prices.get("10T", start=start_T5, end=end, anchor="workback")
+            prices.get("10min", start=start_T5, end=end, anchor="workback")
 
         # verify will return later part of period if strict False
-        df = prices.get("10T", start=start_T5, end=end, anchor="workback", strict=False)
+        df = prices.get(
+            "10min", start=start_T5, end=end, anchor="workback", strict=False
+        )
         assert df.pt.last_ts == end
         assert df.pt.first_ts >= limit_T1
         assert df.index[0].length == TDInterval.T10
@@ -4273,7 +4279,7 @@ class TestGet:
         # verify will return full period if priority "period", althrough with
         # lesser end accuracy
         df = prices.get(
-            "10T", start=start_T5, end=end, anchor="workback", priority="period"
+            "10min", start=start_T5, end=end, anchor="workback", priority="period"
         )
         assert df.pt.last_ts < end
         assert df.pt.first_ts < limit_T1
@@ -4302,7 +4308,7 @@ class TestGet:
         start_H1_oob = xnys.session_offset(start_H1, -2)
         start_T5 = th.get_sessions_range_for_bi(prices, prices.bis.T5)[0]
 
-        end = xnys.session_close(start_T5) - pd.Timedelta(3, "T")
+        end = xnys.session_close(start_T5) - pd.Timedelta(3, "min")
         end = end.astimezone(prices.tz_default)
 
         with pytest.raises(errors.LastIndiceInaccurateError):
@@ -4376,7 +4382,7 @@ class TestGet:
             " intraday base intervals defined."
         )
         with pytest.raises(errors.PricesIntradayIntervalError, match=match):
-            prices_us_daily.get("5T", limit, days=2)
+            prices_us_daily.get("5min", limit, days=2)
 
     def test_raises_intraday_only_direct_errors(self, prices_us, prices_us_intraday):
         """Test get() directly raises expected errors when no daily interval.
@@ -4780,7 +4786,7 @@ class TestPriceAt:
         self.assertions(table, df, indice, values)
 
         # now as after xnys open, verify indice reflects 'now' as live session
-        now = xnys.session_open(session) + pd.Timedelta(22, "T")
+        now = xnys.session_open(session) + pd.Timedelta(22, "min")
         mock_now(monkeypatch, now)
         df = f(None, UTC)
         indice = now
@@ -4871,7 +4877,7 @@ class TestPriceAt:
 
         # verify minute after intraday limit returns via intraday data
         limit_id = prices.limit_intraday()
-        minute = limit_id + pd.Timedelta(1, "H")
+        minute = limit_id + pd.Timedelta(1, "h")
         df = prices.price_at(minute)
         assert df.notna().all(axis=None)
         assert prices._pdata[prices.bis.D1]._table is None
@@ -4880,7 +4886,7 @@ class TestPriceAt:
         self.assert_price_at_rtrn_format(table_, df)
 
         # verify minute prior to intraday limit returns via _price_at_from_daily
-        minute = xnys.previous_close(limit_id) - pd.Timedelta(1, "H")
+        minute = xnys.previous_close(limit_id) - pd.Timedelta(1, "h")
         session_xnys = helpers.to_tz_naive(xnys.minute_to_session(minute))
         session_xhkg = helpers.to_tz_naive(xhkg.minute_to_session(minute, "previous"))
         session_xlon = helpers.to_tz_naive(xlon.minute_to_session(minute, "previous"))
@@ -4931,7 +4937,7 @@ class TestPriceAt:
         xnys = prices.calendar_default
         symb = prices.lead_symbol_default
 
-        delta = pd.Timedelta(33, "T")
+        delta = pd.Timedelta(33, "min")
 
         bi = prices.bis.T1
         session_prev, session = get_conforming_sessions(
@@ -4944,12 +4950,12 @@ class TestPriceAt:
         close = xnys.session_close(session)
         open_next = xnys.session_open(xnys.next_session(session))
 
-        table = prices.get("1T", session_before, session, tzout=UTC)
+        table = prices.get("1min", session_before, session, tzout=UTC)
         tableD1 = prices.get("1D", session_before, session)
 
         delay = 20
         prices = reset_prices(prices)
-        prices._delays[symb] = pd.Timedelta(delay, "T")  # mock delay
+        prices._delays[symb] = pd.Timedelta(delay, "min")  # mock delay
         f = prices.price_at
 
         # prior to xlon open
@@ -4995,14 +5001,14 @@ class TestPriceAt:
             self.assertions(tableD1, df, indice, values)
 
         for i in range(delay):
-            minute = now - pd.Timedelta(i, "T")
+            minute = now - pd.Timedelta(i, "min")
             df = f(minute, UTC)
             indice = minute  # indices as requested minute
             values = {symb: (session, "close")}
             self.assertions(tableD1, df, indice, values)
 
         # verify that on delay limit prices return for intraday data
-        minute = now - pd.Timedelta(delay, "T")
+        minute = now - pd.Timedelta(delay, "min")
         df = f(minute, UTC)
         indice = minute
         values = {symb: (minute, "open")}
@@ -5019,7 +5025,7 @@ class TestPriceAt:
         symb_xhkg = get_symbols_for_calendar(prices, "XHKG")
 
         bi = prices.bis.T1
-        delta = pd.Timedelta(43, "T")
+        delta = pd.Timedelta(43, "min")
 
         # consecutive sessions
         sessions = get_sessions_xnys_xhkg_xlon(bi, 4)
@@ -5043,7 +5049,7 @@ class TestPriceAt:
         # otherwise xlon open is same as xhkg close
         xhkg_xlon_touch = xlon_open == xhkg_close  # touch as opposed to overlap
 
-        table = prices.get("1T", session_before, session_after, tzout=UTC)
+        table = prices.get("1min", session_before, session_after, tzout=UTC)
 
         prices = reset_prices(prices)
         f = prices.price_at
@@ -5233,8 +5239,8 @@ class TestPriceAt:
         symb_xlon = get_symbols_for_calendar(prices, "XLON")
         symb_xhkg = get_symbols_for_calendar(prices, "XHKG")
 
-        delta = pd.Timedelta(43, "T")
-        offset = pd.Timedelta(3, "T")
+        delta = pd.Timedelta(43, "min")
+        offset = pd.Timedelta(3, "min")
         delta_reg = delta - offset
 
         # following assertions from knowledge of standard sessions
@@ -5262,7 +5268,7 @@ class TestPriceAt:
 
         xhkg_xlon_touch = xlon_open == xhkg_close  # touch as opposed to overlap
 
-        table = prices.get("5T", session_before, session_after, tzout=UTC)
+        table = prices.get("5min", session_before, session_after, tzout=UTC)
 
         # reset prices
         prices = reset_prices(prices)
@@ -5533,13 +5539,13 @@ class TestPriceAt:
         symb_xnys = prices.lead_symbol_default
         symb_xhkg = get_symbols_for_calendar(prices, "XHKG")
 
-        delta = pd.Timedelta(63, "T")
-        offset = pd.Timedelta(3, "T")
+        delta = pd.Timedelta(63, "min")
+        offset = pd.Timedelta(3, "min")
         delta_reg = delta - offset
 
         bi = prices.bis.H1
         bi_less_one_min = bi - one_min
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
 
         # consecutive sessions
         sessions = get_sessions_xnys_xhkg_xlon(bi, 4)
@@ -5555,7 +5561,7 @@ class TestPriceAt:
         xhkg_break_start = xhkg.session_break_start(session)
         xhkg_break_end = xhkg.session_break_end(session)
 
-        table = prices.get("1H", session_before, session_after, tzout=UTC)
+        table = prices.get("1h", session_before, session_after, tzout=UTC)
 
         prices = reset_prices(prices)
         f = prices.price_at
@@ -5602,7 +5608,7 @@ class TestPriceAt:
             symb_xhkg: (indice, "open"),
         }
         for i in (0, 1, 2, bi.as_minutes - 2, bi.as_minutes - 1):
-            minute_ = minute + pd.Timedelta(i, "T")
+            minute_ = minute + pd.Timedelta(i, "min")
             df = f(minute_, UTC)
             self.assertions(table, df, indice, values)
 
@@ -5782,13 +5788,13 @@ class TestPriceAt:
         xhkg = prices.calendar_default
         symb_xhkg = prices.lead_symbol_default
 
-        delta = pd.Timedelta(63, "T")
-        offset = pd.Timedelta(3, "T")
+        delta = pd.Timedelta(63, "min")
+        offset = pd.Timedelta(3, "min")
         delta_reg = delta - offset
 
         bi = prices.bis.H1
         bi_less_one_min = bi - one_min
-        half_hour = pd.Timedelta(30, "T")
+        half_hour = pd.Timedelta(30, "min")
         # four consecutive sessions
         sessions = get_conforming_sessions(prices, bi, [xhkg], [session_length_xhkg], 4)
         session_before, session_prev, session, session_after = sessions
@@ -5799,7 +5805,7 @@ class TestPriceAt:
         break_start = xhkg.session_break_start(session)
         break_end = xhkg.session_break_end(session)
 
-        table = prices.get("1H", session_before, session_after, tzout=UTC)
+        table = prices.get("1h", session_before, session_after, tzout=UTC)
 
         prices = reset_prices(prices)
         f = prices.price_at
@@ -5833,7 +5839,7 @@ class TestPriceAt:
         indice = minute
         values = {symb_xhkg: (indice, "open")}
         for i in (0, 1, 2, bi.as_minutes - 2, bi.as_minutes - 1):
-            minute_ = minute + pd.Timedelta(i, "T")
+            minute_ = minute + pd.Timedelta(i, "min")
             df = f(minute_, UTC)
             self.assertions(table, df, indice, values)
 
@@ -5971,7 +5977,7 @@ def test_close_at(prices_us_lon_hk, one_day, monkeypatch):
     # reset prices
     with monkeypatch.context() as monkey:
         mock_today = pd.Timestamp("2021-12-23")
-        now = xhkg.session_close(mock_today) - pd.Timedelta(1, "H")
+        now = xhkg.session_close(mock_today) - pd.Timedelta(1, "h")
         mock_now(monkey, now)
 
         prices = reset_prices(prices)
@@ -6016,9 +6022,9 @@ def test_price_range(prices_us_lon_hk, one_day, monkeypatch):
     symb_xhkg = get_symbols_for_calendar(prices, "XHKG")
 
     _, session = get_sessions_xnys_xhkg_xlon(prices.bis.T1, 2)
-    minute = xlon.session_close(session) - pd.Timedelta(43, "T")
+    minute = xlon.session_close(session) - pd.Timedelta(43, "min")
     session_T5 = get_sessions_xnys_xhkg_xlon(prices.bis.T5, 2)[-1]
-    minute_T5 = xhkg.session_close(session_T5) - pd.Timedelta(78, "T")
+    minute_T5 = xhkg.session_close(session_T5) - pd.Timedelta(78, "min")
 
     def get(kwargs, **others) -> pd.DataFrame:
         return prices.get(**kwargs, **others, composite=True, openend="shorten")
@@ -6195,16 +6201,16 @@ def test_prices_for_symbols(prices_us_lon):
     session = pd.Timestamp("2022-06-08")
     us_open = cal_us.opens[session]
     lon_close = cal_lon.closes[session]
-    assert us_open + pd.Timedelta(1, "H") < lon_close  # verify overlap > one hour
-    start = us_open - pd.Timedelta(2, "H")
-    end = lon_close + pd.Timedelta(2, "H")
+    assert us_open + pd.Timedelta(1, "h") < lon_close  # verify overlap > one hour
+    start = us_open - pd.Timedelta(2, "h")
+    end = lon_close + pd.Timedelta(2, "h")
 
-    _ = prices.get("5T", start, us_open, lead_symbol="AZN.L")
-    _ = prices.get("2T", start, us_open, lead_symbol="AZN.L")
-    _ = prices.get("1T", start, us_open, lead_symbol="AZN.L")
-    _ = prices.get("5T", us_open, end)
-    _ = prices.get("2T", us_open, end)
-    _ = prices.get("1T", us_open, end)
+    _ = prices.get("5min", start, us_open, lead_symbol="AZN.L")
+    _ = prices.get("2min", start, us_open, lead_symbol="AZN.L")
+    _ = prices.get("1min", start, us_open, lead_symbol="AZN.L")
+    _ = prices.get("5min", us_open, end)
+    _ = prices.get("2min", us_open, end)
+    _ = prices.get("1min", us_open, end)
 
     def assertions(
         pdata: data.Data,

--- a/tests/test_calendar_utils.py
+++ b/tests/test_calendar_utils.py
@@ -366,7 +366,7 @@ class CompositeAnswers:
     def sessions_with_gap_after(self) -> pd.DatetimeIndex:
         mask = self.closes >= self.opens.shift(-1)
         if self.side == "both":
-            closes_plus_min = self.closes + pd.Timedelta(1, "T")
+            closes_plus_min = self.closes + pd.Timedelta(1, "min")
             mask = mask | (closes_plus_min == self.opens.shift(-1))
         return self.sessions[~mask][:-1]
 
@@ -962,7 +962,9 @@ class TestCompositeCalendar:
         rtrn = cc.sessions_length()
         pd.testing.assert_series_equal(expected, rtrn, check_freq=False)
 
-    @pytest.mark.parametrize("factor", [pd.Timedelta(v, "T") for v in [5, 7, 11, 300]])
+    @pytest.mark.parametrize(
+        "factor", [pd.Timedelta(v, "min") for v in [5, 7, 11, 300]]
+    )
     def test_is_factor_of_sessions(self, composite_calendars_with_answers, factor):
         cc, answers = composite_calendars_with_answers
         rtrn = cc.is_factor_of_sessions(factor)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -582,8 +582,8 @@ def test_parse_csvs(csv_dir, csv_dir_paths, csv_read_kwargs, symbols):
 def test__get_limits_from_parsed():
     start = start_5t = pd.Timestamp("2023-11-21 09:00", tz="UTC")
     end = end_5t = pd.Timestamp("2023-11-27 16:30", tz="UTC")
-    freq = "5T"
-    delta = pd.Timedelta("10T")
+    freq = "5min"
+    delta = pd.Timedelta("10min")
     index_5t_0 = pd.date_range(start, end - delta, freq=freq)
     index_5t_1 = pd.date_range(start + delta, end - delta, freq=freq)
     index_5t_2 = pd.date_range(start + delta, end, freq=freq)
@@ -616,7 +616,7 @@ def test__get_limits_from_parsed():
 
     expected = (
         {TDInterval.T5: start_5t, TDInterval.D1: start_1d},
-        {TDInterval.T5: end_5t + pd.Timedelta("5T"), TDInterval.D1: end_1d},
+        {TDInterval.T5: end_5t + pd.Timedelta("5min"), TDInterval.D1: end_1d},
     )
 
     assert rtrn == expected
@@ -779,7 +779,7 @@ def test_tables(csv_dir, symbols, calendars, res_us_lon_hk):
 
     for interval, pdata in prices._pdata.items():
         table = pdata._table
-        res = res_us_lon_hk[0][interval.as_pdfreq[-1::-1]]  # just reversed freq str
+        res = res_us_lon_hk[0][interval.name]
         if interval.is_daily:
             expected = res.loc[table.index[0] : table.index[-1]].dropna(
                 how="all", axis=0

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -353,7 +353,7 @@ def assert_single_daterange(
     assert table is not None
     assert_table_matches(table, daterange, df)
     assert mr_admin.last_request is None
-    delta = delta if delta == helpers.ONE_DAY else pd.Timedelta(30, "T")
+    delta = delta if delta == helpers.ONE_DAY else pd.Timedelta(30, "min")
     from_ += delta
     to -= delta
     table = data.get_table((from_, to))
@@ -412,9 +412,9 @@ class TestRanges:
         rngs.append(((from_minute, to_minute), (from_session, to_session)))
 
         from_session = cal.session_offset(end_session, -5)
-        from_minute = cal.session_open(from_session) - pd.Timedelta(70, "T")
+        from_minute = cal.session_open(from_session) - pd.Timedelta(70, "min")
         to_session = cal.session_offset(from_session, 2)
-        to_minute = cal.session_close(to_session) + pd.Timedelta(70, "T")
+        to_minute = cal.session_close(to_session) + pd.Timedelta(70, "min")
         rngs.append(((from_minute, to_minute), (from_session, to_session)))
 
         yield rngs
@@ -487,7 +487,7 @@ class TestRanges:
 
     @pytest.fixture(scope="class")
     def thirty_mins(self) -> abc.Iterator[pd.Timedelta]:
-        yield pd.Timedelta(30, "T")
+        yield pd.Timedelta(30, "min")
 
     def test_extending_requested_range(
         self,
@@ -903,7 +903,7 @@ class TestRanges:
 
         # now, and hence left_bound, set to a time that provides for 1H bi
         # to fall on frequency, save for left_bound + (2*delta)
-        now = cal.previous_open(pd.Timestamp.now()) + pd.Timedelta(59, "T")
+        now = cal.previous_open(pd.Timestamp.now()) + pd.Timedelta(59, "min")
         set_now(now)
         if bi_daily:
             left_bound = today - left_limit
@@ -1012,7 +1012,7 @@ class TestRanges:
         table = data.get_table(dr)
         assert_table_matches(table, dr, df)
         assert admin.last_request is None
-        delta = delta if delta == helpers.ONE_DAY else pd.Timedelta(30, "T")
+        delta = delta if delta == helpers.ONE_DAY else pd.Timedelta(30, "min")
         from_ = dr[0] + delta
         to = dr[1] - delta
         table = data.get_table((from_, to))
@@ -1066,12 +1066,12 @@ class TestRanges:
             )
 
         if not bi_daily:
-            now = cal.session_close(last_session) - pd.Timedelta(90, "T")
+            now = cal.session_close(last_session) - pd.Timedelta(90, "min")
             data, _ = get_data(now)
             set_now(now)
             assert data.rl == now + bi
             for _ in range(18):
-                now += pd.Timedelta(10, "T")
+                now += pd.Timedelta(10, "min")
                 set_now(now)
                 assert data.rl == now + bi
                 assert not data.to_rl
@@ -1093,7 +1093,7 @@ class TestRanges:
             bi = data.bi
             from_, to = dr
             # discount calculation reasonable only given the bis tested (1T, 1H, 1D)
-            discount = max(bi, delay + pd.Timedelta(10, "T"))
+            discount = max(bi, delay + pd.Timedelta(10, "min"))
             rightmost = now - discount
 
             table_dr = dr[0], min(dr[1], now + bi)
@@ -1177,7 +1177,7 @@ class TestRanges:
                 now = now.normalize().tz_convert(None)
                 dr = start, now
 
-            for delay in [no_delay, pd.Timedelta(15, "T")]:
+            for delay in [no_delay, pd.Timedelta(15, "min")]:
                 # on right limit
                 data, admin = get_data(now, delay)
                 table = data.get_table(dr)
@@ -1248,4 +1248,4 @@ class TestRanges:
         session, _ = session_ends
         session_open = xlon.session_open(session)
         with pytest.raises(errors.PricesUnavailableFromSourceError):
-            data.get_table((session_open, session_open + pd.Timedelta(30, "T")))
+            data.get_table((session_open, session_open + pd.Timedelta(30, "min")))

--- a/tests/test_daterange.py
+++ b/tests/test_daterange.py
@@ -2070,14 +2070,14 @@ class TestGetterIntraday:
         # test trading_minute
         session = ans.sessions_sample[-4]
         open_ = ans.opens[session]
-        now = open_ + pd.Timedelta(20, "T")
+        now = open_ + pd.Timedelta(20, "min")
         monkeypatch.setattr("pandas.Timestamp.now", lambda *a, **k: now)
         drg = self.get_drg(cal, pp, interval=interval)
         end = open_ + (TDInterval.T15 * 2)  # end is end of current live interval
         assert drg.end_now == drg.get_end(None) == (end, now + one_min)
 
         # test trading minute with delay
-        delay = pd.Timedelta(10, "T")
+        delay = pd.Timedelta(10, "min")
         drg = self.get_drg(cal, pp, interval=interval, delay=delay)
         end = open_ + TDInterval.T15
         assert drg.end_now == drg.get_end(None) == (end, now + one_min - delay)
@@ -2088,14 +2088,14 @@ class TestGetterIntraday:
             return
         session = sessions[-4]
         close = ans.closes[session]
-        now = close + pd.Timedelta(10, "T")
+        now = close + pd.Timedelta(10, "min")
         monkeypatch.setattr("pandas.Timestamp.now", lambda *a, **k: now)
         drg = self.get_drg(cal, pp, interval=TDInterval.T1)
         assert drg.end_now == drg.get_end(None) == (close, close)
 
-        delay = pd.Timedelta(15, "T")
+        delay = pd.Timedelta(15, "min")
         drg = self.get_drg(cal, pp, interval=TDInterval.T1, delay=delay)
-        end = close - pd.Timedelta(5, "T") + one_min  # returns right of live indice
+        end = close - pd.Timedelta(5, "min") + one_min  # returns right of live indice
         assert drg.end_now == drg.get_end(None) == (end, now + one_min - delay)
 
         # verify None input to `get_end` returns any fixed right limit
@@ -2129,9 +2129,9 @@ class TestGetterIntraday:
         )
 
         # verify that drg_wb behaves as drg_bi, i.e. aligning based on bi, not dsi
-        delta = pd.Timedelta(4, "T")
+        delta = pd.Timedelta(4, "min")
         minutes = pd.date_range(open_ - delta, close + delta, freq=delta)
-        delta = pd.Timedelta(7, "T")
+        delta = pd.Timedelta(7, "min")
         minutes = minutes.union(pd.date_range(open_ - delta, close + delta, freq=delta))
 
         for minute in minutes:
@@ -2231,7 +2231,7 @@ class TestGetterIntraday:
             duration_insert = ""
             if anchor is Anchor.WORKBACK:
                 assert duration is not None
-                duration_ = pd.Timedelta(duration, "T")
+                duration_ = pd.Timedelta(duration, "min")
                 duration_insert = f"\nPeriod duration evaluated as {duration_}."
             return re.escape(
                 f"Period does not span a full indice of length {final_interval}."
@@ -2365,7 +2365,7 @@ class TestGetterIntraday:
 
         # verify when single interval would comprise minutes from both end of
         # previous session and start of session
-        delta = pd.Timedelta(3, "T")
+        delta = pd.Timedelta(3, "min")
         pp = get_pp_default()
         pp["start"] = start = prev_session_close - dsi + delta
         pp["end"] = end = session_open + delta
@@ -2988,7 +2988,7 @@ class TestGetterIntraday:
         end, end_accuracy = drg.end_now
 
         minutes = 5
-        pp["start"] = start = end - pd.Timedelta(minutes, "T")
+        pp["start"] = start = end - pd.Timedelta(minutes, "min")
 
         # on now
         pp["minutes"] = minutes
@@ -3015,7 +3015,7 @@ class TestGetterIntraday:
 
         # on limit
         minutes = 5
-        pp["end"] = end = limit + pd.Timedelta(minutes, "T")
+        pp["end"] = end = limit + pd.Timedelta(minutes, "min")
         pp["minutes"] = minutes
         drg = self.get_drg(cal, pp, interval=bi, limit=limit, strict=False)
         assert drg.daterange == ((limit, end), end)
@@ -3112,8 +3112,8 @@ class TestGetterIntraday:
         kwargs = {"interval": TDInterval.H1, "ds_interval": TDInterval.H2}
 
         exp_start = open_
-        exp_end = close + pd.Timedelta(90, "T")
-        exp_end_tight = close + pd.Timedelta(30, "T")
+        exp_end = close + pd.Timedelta(90, "min")
+        exp_end_tight = close + pd.Timedelta(30, "min")
         exp_end_accuracy = close
 
         # verify daterange same as daterange_tight when Alignment BI
@@ -3148,7 +3148,7 @@ class TestGetterIntraday:
         # duration < final interval
         pp["minutes"] = minutes = pp["minutes"] - 1
         drg = self.get_drg(cal, pp, **drg_kwargs)
-        duration = pd.Timedelta(minutes, "T")
+        duration = pd.Timedelta(minutes, "min")
         match = re.escape(
             f"Period duration shorter than interval. Interval is {base_interval}"
             f" although period duration is only {duration}."
@@ -3212,7 +3212,7 @@ class TestGetterIntraday:
         assert drg_wb_dr[0][1] == drg_wb_dr[1] == start + dsi + one_min
 
         # verify for prior_start that represent an interval that crosses sessions
-        delta = pd.Timedelta(7, "T")
+        delta = pd.Timedelta(7, "min")
         pp["start"] = start = open_ + delta
         drg_open, drg_wb = get_drgs(pp)
         end_ = start + dsi + one_min

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -38,8 +38,8 @@ def test_constants():
     # Just to make sure they aren't inadvertently changed
     assert m.UTC is ZoneInfo("UTC")
     assert m.ONE_DAY == pd.Timedelta(1, "D")
-    assert m.ONE_MIN == pd.Timedelta(1, "T")
-    assert m.ONE_SEC == pd.Timedelta(1, "S")
+    assert m.ONE_MIN == pd.Timedelta(1, "min")
+    assert m.ONE_SEC == pd.Timedelta(1, "s")
 
 
 def test_is_date(one_min):
@@ -323,7 +323,7 @@ def test_resample(intraday_pt):
     df = intraday_pt.pt.utc
 
     df = df.loc["2021-12-17":"2021-12-20"].copy()
-    rtrn = f(df.pt.indexed_left, "1H")
+    rtrn = f(df.pt.indexed_left, "1h")
 
     # create expected return
     groups = []
@@ -359,8 +359,8 @@ def test_resample(intraday_pt):
     # add rows with missing values to expected
     index = pd.date_range(
         start=df.pt.first_ts,
-        end=df.pt.last_ts - pd.Timedelta(1, "H"),
-        freq="1H",
+        end=df.pt.last_ts - pd.Timedelta(1, "h"),
+        freq="1h",
         name="left",
     )
     expected = expected.reindex(index)

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -243,7 +243,7 @@ def stricts() -> abc.Iterator[list[bool]]:
 
 @pytest.fixture
 def intrvls() -> abc.Iterator[tuple[None, str]]:
-    yield (None, "5T")
+    yield (None, "5min")
 
 
 @pytest.fixture
@@ -362,7 +362,7 @@ class TestStartEnd:
         # verify as required at the edge
 
         end = ends_T5[0]
-        one_min = pd.Timedelta(1, "T")
+        one_min = pd.Timedelta(1, "min")
         limit_start_5T, _ = prices.limits[prices.bis.T5]
         start_ool = limit_start_5T - prices.bis.T5
         start_valid = start_ool + one_min
@@ -375,7 +375,7 @@ class TestStartEnd:
             check(prices, df, prices.bis.T5, end=expected_end_T5)
             # check when explicitly defining interval
             df = prices.get(
-                "5T", start=start_valid, end=end, priority=priority, strict=strict
+                "5min", start=start_valid, end=end, priority=priority, strict=strict
             )
             check(prices, df, prices.bis.T5, end=expected_end_T5)
 
@@ -400,7 +400,7 @@ class TestStartEnd:
         for priority in priorities:
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
                 prices.get(
-                    "5T", start=start_ool, end=end, priority=priority, strict=True
+                    "5min", start=start_ool, end=end, priority=priority, strict=True
                 )
 
         # verify doesn't raise when strict False
@@ -409,7 +409,7 @@ class TestStartEnd:
             check(prices, df, prices.bis.T5, end=expected_end_T5)
             # check when explicitly defining interval
             df = prices.get(
-                "5T", start=start_ool, end=end, priority=priority, strict=False
+                "5min", start=start_ool, end=end, priority=priority, strict=False
             )
             check(prices, df, prices.bis.T5, end=expected_end_T5)
 
@@ -481,21 +481,21 @@ class TestStartEnd:
         for start, priority in itertools.product(all_starts, priorities):
             # as neither period nor end can be met return will be based on highest interval
             df = prices.get(start=start, end=rorl, priority=priority, strict=False)
-            mod = pd.Timedelta((start.time().minute % 5), "T")
+            mod = pd.Timedelta((start.time().minute % 5), "min")
             expected_start = start if not mod else start + (prices.bis.T5 - mod)
             check(prices, df, prices.bis.T5, start=expected_start)
             # verify when explicitly defining interval
             df = prices.get(
-                "5T", start=start, end=rorl, priority=priority, strict=False
+                "5min", start=start, end=rorl, priority=priority, strict=False
             )
             check(prices, df, prices.bis.T5, start=expected_start)
 
         # check when define lower interval that returns at that interval
         for start, priority in itertools.product(starts_T2, priorities):
             df = prices.get(
-                "2T", start=start, end=rorl, priority=priority, strict=False
+                "2min", start=start, end=rorl, priority=priority, strict=False
             )
-            mod = pd.Timedelta((start.time().minute % 2), "T")
+            mod = pd.Timedelta((start.time().minute % 2), "min")
             expected_start = start if not mod else start + (prices.bis.T2 - mod)
             check(prices, df, prices.bis.T2, start=expected_start)
 
@@ -513,7 +513,7 @@ class TestStartEnd:
             check(prices, df, prices.bis.T5, start=expected_start_T5)
             # check when explicitly defining interval
             df = prices.get(
-                "5T", start=start, end=end_valid, priority=priority, strict=strict
+                "5min", start=start, end=end_valid, priority=priority, strict=strict
             )
             check(prices, df, prices.bis.T5, start=expected_start_T5)
 
@@ -559,7 +559,7 @@ class TestStartEnd:
         for priority in priorities:
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
                 prices.get(
-                    "5T", start=start, end=end_ool_5, priority=priority, strict=True
+                    "5min", start=start, end=end_ool_5, priority=priority, strict=True
                 )
 
         # verify doesn't raise when False
@@ -571,7 +571,9 @@ class TestStartEnd:
         assert df.index[-1].right == end_ool_1
 
         # will be fulfilled by 1T data within confined of what's available
-        df = prices.get("5T", start=start, end=end_ool_5, priority="end", strict=False)
+        df = prices.get(
+            "5min", start=start, end=end_ool_5, priority="end", strict=False
+        )
         assert isinstance(df, pd.DataFrame)
         assert df.pt.interval == prices.bis.T5
         assert df.index[0].left == prices.limits[prices.bis.T1][0]
@@ -689,13 +691,17 @@ class TestStartEnd:
         )
         with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
             prices.get(
-                "5T", start=start_ool_T5, end=end_ool_T5, priority="period", strict=True
+                "5min",
+                start=start_ool_T5,
+                end=end_ool_T5,
+                priority="period",
+                strict=True,
             )
         with pytest.raises(errors.LastIndiceInaccurateError):  # as prior reasoning
             prices.get(start=start_ool_T5, end=end_ool_T5, priority="end", strict=True)
         with pytest.raises(errors.PricesIntradayUnavailableError):
             prices.get(
-                "5T", start=start_ool_T5, end=end_ool_T5, priority="end", strict=True
+                "5min", start=start_ool_T5, end=end_ool_T5, priority="end", strict=True
             )
 
         # strict False
@@ -711,7 +717,7 @@ class TestStartEnd:
         check(prices, df, prices.bis.T1, end=end_ool_T5)
 
         # will meet with downsampled 1T data that can meet end
-        df = prices.get("5T", start_ool_T5, end_ool_T5, priority="end", strict=False)
+        df = prices.get("5min", start_ool_T5, end_ool_T5, priority="end", strict=False)
         check(prices, df, prices.bis.T5, prices.limits[prices.bis.T1][0], end_ool_T5)
 
         # going way out
@@ -892,7 +898,7 @@ class TestDuration:
         df = prices.get(start=loll, days=days, priority="end", strict=False)
         check(prices, df, prices.bis.T2, end=end)
 
-        mod = pd.Timedelta((end.time().minute % 5), "T")
+        mod = pd.Timedelta((end.time().minute % 5), "min")
         expected_end = end + (prices.bis.T5 - mod)
         for intrvl, priority in itertools.product(intrvls, priorities):
             if intrvl is None and priority == "end":
@@ -910,7 +916,11 @@ class TestDuration:
         for priority in priorities:
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
                 prices.get(
-                    "5T", start=loll, days=days_to_T5[0], priority=priority, strict=True
+                    "5min",
+                    start=loll,
+                    days=days_to_T5[0],
+                    priority=priority,
+                    strict=True,
                 )
 
         # end defined ool
@@ -921,7 +931,7 @@ class TestDuration:
         # value such that aligns with 5T. start will then be evaluated off this aligned
         # value, such that falls earlier than what would be the 2T target
         days, start = days_back_to_T2
-        mod = pd.Timedelta((end.time().minute % 5), "T")
+        mod = pd.Timedelta((end.time().minute % 5), "min")
         expected_start = start - (prices.bis.T5 - mod)
         for intrvl, priority in itertools.product(intrvls, priorities):
             df = prices.get(
@@ -1025,7 +1035,7 @@ class TestDuration:
         df = prices.get(end=end, days=days, priority="end", strict=False)
         check(prices, df, prices.bis.T2, end=end)
 
-        mod = pd.Timedelta((end.time().minute % 5), "T")
+        mod = pd.Timedelta((end.time().minute % 5), "min")
         expected_end = end - mod
         for intrvl, priority in itertools.product(intrvls, priorities):
             if intrvl is None and priority == "end":
@@ -1040,7 +1050,7 @@ class TestDuration:
         )
         for priority in priorities:
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
-                prices.get("5T", end=end, days=days, priority=priority, strict=True)
+                prices.get("5min", end=end, days=days, priority=priority, strict=True)
 
         # start defined within limits
         # strict True
@@ -1048,7 +1058,7 @@ class TestDuration:
         # priority not important as cannot meet end, will be returned at highest
         # avaialble intraday interval, i.e. 5T
         days, start = days_back_to_T2
-        mod = pd.Timedelta((end.time().minute % 5), "T")
+        mod = pd.Timedelta((end.time().minute % 5), "min")
         expected_start = start + mod
 
         for intrvl, priority in itertools.product(intrvls, priorities):
@@ -1272,16 +1282,16 @@ class TestOutsideLimits:
         for priority, strict in itertools.product(priorities, stricts):
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
                 prices.get(
-                    "5T",
+                    "5min",
                     start=loll,
                     end=loll + one_day,
                     priority=priority,
                     strict=strict,
                 )
             with pytest.raises(errors.PricesIntradayUnavailableError):
-                prices.get("5T", start=loll, days=2, priority=priority, strict=strict)
+                prices.get("5min", start=loll, days=2, priority=priority, strict=strict)
             with pytest.raises(errors.PricesIntradayUnavailableError):
-                prices.get("5T", end=loll, days=2, priority=priority, strict=strict)
+                prices.get("5min", end=loll, days=2, priority=priority, strict=strict)
 
         # interval inferred
         match_start = "Given the parameters receieved, the interval was inferred as intraday although the request can only be met with daily data. To return daily prices pass `interval` as a daily interval, for example '1D'.\nNB. The interval will only be inferred as daily if `end` and `start` are defined (if passed) as sessions (timezone naive and with time component as 00:00) and any duration is defined in terms of either `days` or `weeks`, `months` and `years`. Also, if both `start` and `end` are passed then the distance between them should be no less than 6 sessions."
@@ -1429,16 +1439,16 @@ class TestOutsideLimits:
         for priority, strict in itertools.product(priorities, stricts):
             with pytest.raises(errors.StartTooLateError, match=match_stl):
                 prices.get(
-                    "5T",
+                    "5min",
                     start=rorl,
                     end=rorl + one_day * 2,
                     priority=priority,
                     strict=strict,
                 )
             with pytest.raises(errors.StartTooLateError):
-                prices.get("5T", start=rorl, days=2, priority=priority, strict=strict)
+                prices.get("5min", start=rorl, days=2, priority=priority, strict=strict)
             with pytest.raises(errors.PricesIntradayUnavailableError, match=match):
-                prices.get("5T", end=rorl, days=2, priority=priority, strict=strict)
+                prices.get("5min", end=rorl, days=2, priority=priority, strict=strict)
 
         # interval inferred as intraday
         match = re.escape(

--- a/tests/test_mptypes.py
+++ b/tests/test_mptypes.py
@@ -38,7 +38,7 @@ def test_pandasfreq():
         return arg
 
     # verify valid input
-    freq = "3H"
+    freq = "3h"
     rtrn = mock_func(freq)
     assert rtrn == freq
     # verify mptype property

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -28,7 +28,7 @@ from market_prices.helpers import UTC
 
 @pytest.fixture
 def datetime_index_hourly_freq():
-    yield pd.date_range("2021-05-01 12:00", periods=10, freq="1H")
+    yield pd.date_range("2021-05-01 12:00", periods=10, freq="1h")
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def interval_index_non_overlapping(
     datetime_index_hourly_freq,
 ) -> abc.Iterator[pd.IntervalIndex]:
     """1H between indices. Interval 30min. 30min gap from right to next left."""
-    right = datetime_index_hourly_freq + pd.Timedelta(30, "T")
+    right = datetime_index_hourly_freq + pd.Timedelta(30, "min")
     yield pd.IntervalIndex.from_arrays(datetime_index_hourly_freq, right)
 
 
@@ -54,7 +54,7 @@ def interval_index_overlapping(
     """One indice of interval index fully overlaps following indice."""
     index = interval_index_non_overlapping
     i = 3
-    new_indice = pd.Interval(index[i].left, index[i + 1].left + pd.Timedelta(5, "T"))
+    new_indice = pd.Interval(index[i].left, index[i + 1].left + pd.Timedelta(5, "min"))
     index = index.insert(i, new_indice)
     index = index.drop(index[i + 1])
     assert index.is_monotonic_increasing
@@ -70,7 +70,7 @@ def interval_index_fully_overlapping(
     index = interval_index_non_overlapping
     i = 3
     indice = pd.Interval(
-        index[i].left - pd.Timedelta(5, "T"), index[i].right + pd.Timedelta(5, "T")
+        index[i].left - pd.Timedelta(5, "min"), index[i].right + pd.Timedelta(5, "min")
     )
     index = index.insert(i, indice)
     assert index.is_overlapping
@@ -84,8 +84,8 @@ def interval_index_not_monotonoic_increasing(
     index = interval_index_non_overlapping
     i = 3
     new_indice = pd.Interval(
-        index[i].right + pd.Timedelta(5, "T"),
-        index[i + 1].left - pd.Timedelta(5, "T"),
+        index[i].right + pd.Timedelta(5, "min"),
+        index[i + 1].left - pd.Timedelta(5, "min"),
         closed=index.closed,
     )
     index = index.insert(i, new_indice)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -183,7 +183,7 @@ class TestParseStartEnd:
 
     @pytest.fixture(scope="class")
     def delays(self) -> abc.Iterator[tuple[pd.Timedelta, pd.Timedelta]]:
-        yield pd.Timedelta(0), pd.Timedelta(15, "T")
+        yield pd.Timedelta(0), pd.Timedelta(15, "min")
 
     @pytest.fixture(scope="class")
     def as_times(self) -> abc.Iterator[typing.Literal[True]]:

--- a/tests/test_tutorial_helpers.py
+++ b/tests/test_tutorial_helpers.py
@@ -339,7 +339,7 @@ def test_get_conforming_sessions(xlon, xhkg, xnys):
     with pytest.raises(errors.TutorialDataUnavailableError, match=match(*args)):
         f_cc_var(*args)
 
-    length = pd.Timedelta(4, "H")
+    length = pd.Timedelta(4, "h")
     lengths = [[length]]
     num = 1
     msg = match(cals, [[length] * num], start, end)
@@ -372,7 +372,7 @@ def test_get_conforming_sessions(xlon, xhkg, xnys):
     cals = [xlon, xnys]
     cc = calutils.CompositeCalendar(cals)
     full_session_xnys = pd.Timedelta(hours=6, minutes=30)
-    full_session_cc = pd.Timedelta(13, "H")
+    full_session_cc = pd.Timedelta(13, "h")
 
     length_by_cal = [full_session_xlon, full_session_xnys]
     length_cc = full_session_cc
@@ -531,7 +531,7 @@ def test_get_conforming_sessions(xlon, xhkg, xnys):
     ]
     lengths_cc = [
         full_session_cc,
-        pd.Timedelta(11, "H"),
+        pd.Timedelta(11, "h"),
         full_session_xnys,
         full_session_cc,
         full_session_cc,

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -533,7 +533,7 @@ class TestConstructor:
         expected_delays = delays
         for k, delay in prices.delays.items():
             assert isinstance(delay, pd.Timedelta)
-            assert delay == pd.Timedelta(expected_delays[k], "T")
+            assert delay == pd.Timedelta(expected_delays[k], "min")
 
     def test_adj_close(self):
         """Verify `adj_close` parameter returns alternative close col.
@@ -634,17 +634,17 @@ class TestConstructor:
 
 @pytest.fixture
 def session_length_xnys() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(6.5, "H")
+    yield pd.Timedelta(6.5, "h")
 
 
 @pytest.fixture
 def session_length_xhkg() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(6.5, "H")
+    yield pd.Timedelta(6.5, "h")
 
 
 @pytest.fixture
 def session_length_xlon() -> abc.Iterator[pd.Timedelta]:
-    yield pd.Timedelta(8.5, "H")
+    yield pd.Timedelta(8.5, "h")
 
 
 @pytest.fixture(scope="module")
@@ -1161,7 +1161,7 @@ class TestRequestDataIntraday:
         xlon = prices.calendars["AZN.L"]
 
         common_index = xnys.opens[slc].index.intersection(xlon.opens[slc].index)
-        delta = pd.Timedelta(2, "H")
+        delta = pd.Timedelta(2, "h")
 
         # don't use first index
         for i in reversed(range(len(common_index) - 1)):
@@ -1186,7 +1186,7 @@ class TestRequestDataIntraday:
         interval = prices.BaseInterval.T5
         _, slc = get_data_bounds(prices, interval)
 
-        delta = pd.Timedelta(20, "T")
+        delta = pd.Timedelta(20, "min")
         start = cc.opens[slc].iloc[0] + delta
         end = cc.closes[slc].iloc[-1] - delta
 
@@ -1244,7 +1244,7 @@ class TestRequestDataIntraday:
         start = xlon.session_open(session_start)
         end = xnys.session_close(session_end)
         df = prices._request_data(interval, start, end)
-        delta = pd.Timedelta(20, "T")
+        delta = pd.Timedelta(20, "min")
         start_ = start - delta
         end_ = end + delta
         df_not_mins = prices._request_data(interval, start_, end_)
@@ -1266,7 +1266,7 @@ class TestRequestDataIntraday:
     def test_start_none(self, pricess):
         """Verify as expected when start is None."""
         prices = pricess["inc_247"]
-        end = pd.Timestamp.now().floor("T")
+        end = pd.Timestamp.now().floor("min")
         start = None
         for interval in prices.BaseInterval[:-1]:
             match = (
@@ -1282,7 +1282,7 @@ class TestRequestDataIntraday:
         prices = pricess["inc_247"]
         start = pd.Timestamp.now(tz=UTC).floor("D") - pd.Timedelta(2, "D")
         for interval in prices.BaseInterval[:-1]:
-            now = pd.Timestamp.now(tz=UTC).floor("T")
+            now = pd.Timestamp.now(tz=UTC).floor("min")
             end = now + interval
             df = prices._request_data(interval, start, end)
             num_rows = (now - start) / interval
@@ -1295,7 +1295,7 @@ class TestRequestDataIntraday:
         prices = m.PricesYahoo(symbol, calendars="24/7", delays=delay_mins)
         cal = prices.calendars[symbol]
         cc = calutils.CompositeCalendar([cal])
-        delay = pd.Timedelta(delay_mins, "T")
+        delay = pd.Timedelta(delay_mins, "min")
         start = pd.Timestamp.now(tz=UTC).floor("D") - pd.Timedelta(2, "D")
         pp = {
             "minutes": 0,
@@ -1314,7 +1314,7 @@ class TestRequestDataIntraday:
             )
             (_, end), _ = drg.daterange
             df = prices._request_data(interval, start, end)
-            now = pd.Timestamp.now(tz=UTC).floor("T")
+            now = pd.Timestamp.now(tz=UTC).floor("min")
             num_rows = (now - delay - start) / interval
             num_rows = np.ceil(num_rows) if num_rows % 1 else num_rows + 1
             expected_end = start + (num_rows * interval)
@@ -1329,7 +1329,7 @@ class TestRequestDataIntraday:
         prices = pricess["only_247"]
         interval = prices.BaseInterval.T1
         for days in [5, 6, 7, 11, 12, 13]:
-            end = pd.Timestamp.now(tz=UTC).ceil("T")
+            end = pd.Timestamp.now(tz=UTC).ceil("min")
             start = end - pd.Timedelta(days, "D")
             df = prices._request_data(interval, start, end)
             num_expected_rows = days * 24 * 60
@@ -1417,22 +1417,22 @@ class TestRequestDataIntraday:
         prices = pricess["us"]
         symbol = prices.symbols[0]
         cal = prices.calendars[symbol]
-        now = pd.Timestamp.now(UTC).floor("T")
+        now = pd.Timestamp.now(UTC).floor("min")
         session = cal.minute_to_past_session(now, 2)
         session = get_valid_session(session, cal, "previous")
         # extra 30T to cover unaligned end of 1H interval
-        end = cal.session_close(session) + pd.Timedelta(30, "T")
-        start = cal.session_open(session) + pd.Timedelta(1, "H")
+        end = cal.session_close(session) + pd.Timedelta(30, "min")
+        start = cal.session_open(session) + pd.Timedelta(1, "h")
         assertions(prices, start, end)
 
         # Verify for lon prices
         prices = m.PricesYahoo("AZN.L", calendars="XLON", delays=15)
         cal = prices.calendars["AZN.L"]
-        now = pd.Timestamp.now(UTC).floor("T")
+        now = pd.Timestamp.now(UTC).floor("min")
         session = cal.minute_to_past_session(now, 2)
         session = get_valid_session(session, cal, "previous")
         # extra 30T to cover unaligned end of 1H interval
-        end = cal.session_close(session) + pd.Timedelta(30, "T")
+        end = cal.session_close(session) + pd.Timedelta(30, "min")
         start = cal.session_open(session)
         prev_close = cal.previous_close(session)
         assertions(prices, start, end, prev_close)


### PR DESCRIPTION
Updates dependencies.

Fixes pandas 2.2 deprecation warnings concerning deprecation of frequency units "T", "H" and "S" in favor of "min", "h" and "s".

Maintains "T" and "H" as valid units for the 'interval' arg of `PricesBase.get`.

Preemptively constrains numpy dependency to <2 in anticipation of breaking changes with the upcoming major release 2.0.