### PR TITLE
Update Deps / Bump upper supported Python version to 3.12

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -6,15 +6,15 @@
 #
 beautifulsoup4==4.12.3
     # via yahooquery
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-idna==3.6
+idna==3.7
     # via requests
 korean-lunar-calendar==0.3.1
     # via exchange-calendars
@@ -25,18 +25,18 @@ numpy==1.26.4
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pyluach==2.2.0
     # via exchange-calendars
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -48,14 +48,14 @@ soupsieve==2.5
     # via beautifulsoup4
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
 tzdata==2024.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -20,7 +20,7 @@ korean-lunar-calendar==0.3.1
     # via exchange-calendars
 lxml==4.9.4
     # via yahooquery
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -55,7 +55,7 @@ ndindex==1.8
     # via blosc2
 numexpr==2.10.1
     # via tables
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   blosc2
     #   exchange-calendars

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -8,11 +8,11 @@ attrs==23.2.0
     # via hypothesis
 beautifulsoup4==4.12.3
     # via yahooquery
-black==24.2.0
+black==24.4.2
     # via market-prices (pyproject.toml)
 blosc2==2.5.1
     # via tables
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -23,21 +23,21 @@ colorama==0.4.6
     #   click
     #   pytest
     #   tqdm
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-flake8==7.0.0
+flake8==7.1.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.98.8
+hypothesis==6.104.0
     # via market-prices (pyproject.toml)
-idna==3.6
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -47,13 +47,13 @@ lxml==4.9.4
     # via yahooquery
 mccabe==0.7.0
     # via flake8
-msgpack==1.0.7
+msgpack==1.0.8
     # via blosc2
 mypy-extensions==1.0.0
     # via black
 ndindex==1.8
     # via blosc2
-numexpr==2.9.0
+numexpr==2.10.1
     # via tables
 numpy==1.26.4
     # via
@@ -63,27 +63,27 @@ numpy==1.26.4
     #   numexpr
     #   pandas
     #   tables
-packaging==23.2
+packaging==24.1
     # via
     #   black
     #   pytest
     #   tables
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pathspec==0.12.1
     # via black
-platformdirs==4.2.0
+platformdirs==4.2.2
     # via black
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
@@ -91,17 +91,17 @@ pyflakes==3.2.0
     # via flake8
 pyluach==2.2.0
     # via exchange-calendars
-pytest==8.0.1
+pytest==8.2.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -123,16 +123,16 @@ tomli==2.0.1
     #   pytest
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black
 tzdata==2024.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -86,7 +86,7 @@ nodeenv==1.9.1
     # via pre-commit
 numexpr==2.10.1
     # via tables
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   blosc2
     #   exchange-calendars

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-astroid==3.0.3
+astroid==3.2.2
     # via pylint
 attrs==23.2.0
     # via hypothesis
 beautifulsoup4==4.12.3
     # via yahooquery
-black==24.2.0
+black==24.4.2
     # via market-prices (pyproject.toml)
 blosc2==2.5.1
     # via tables
-build==1.0.3
+build==1.2.1
     # via pip-tools
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -37,27 +37,27 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-filelock==3.13.1
+filelock==3.15.4
     # via virtualenv
-flake8==7.0.0
+flake8==7.1.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.98.8
+hypothesis==6.104.0
     # via market-prices (pyproject.toml)
-identify==2.5.35
+identify==2.5.36
     # via pre-commit
-idna==3.6
+idna==3.7
     # via requests
-importlib-metadata==7.0.1
+importlib-metadata==7.2.1
     # via build
 iniconfig==2.0.0
     # via pytest
@@ -71,9 +71,9 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-msgpack==1.0.7
+msgpack==1.0.8
     # via blosc2
-mypy==1.8.0
+mypy==1.10.1
     # via market-prices (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -82,9 +82,9 @@ mypy-extensions==1.0.0
     #   mypy
 ndindex==1.8
     # via blosc2
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pre-commit
-numexpr==2.9.0
+numexpr==2.10.1
     # via tables
 numpy==1.26.4
     # via
@@ -95,63 +95,63 @@ numpy==1.26.4
     #   pandas
     #   pandas-stubs
     #   tables
-packaging==23.2
+packaging==24.1
     # via
     #   black
     #   build
     #   pytest
     #   tables
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==2.2.0.240218
+pandas-stubs==2.2.2.240603
     # via market-prices (pyproject.toml)
 pathspec==0.12.1
     # via black
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via market-prices (pyproject.toml)
-platformdirs==4.2.0
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-pre-commit==3.6.2
+pre-commit==3.7.1
     # via market-prices (pyproject.toml)
 py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.2.0
     # via flake8
-pylint==3.0.3
+pylint==3.2.3
     # via market-prices (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pytest==8.0.1
+pytest==8.2.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via pre-commit
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -174,17 +174,16 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pylint
-    #   pyproject-hooks
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.5
     # via pylint
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
-types-pytz==2024.1.0.20240203
+types-pytz==2024.1.0.20240417
     # via pandas-stubs
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   astroid
     #   black
@@ -195,17 +194,17 @@ tzdata==2024.1
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)
-virtualenv==20.25.0
+virtualenv==20.26.3
     # via pre-commit
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
 yahooquery==2.3.7
     # via market-prices (pyproject.toml)
-zipp==3.17.0
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Education",
     "Topic :: Office/Business :: Financial",
@@ -52,7 +53,7 @@ classifiers = [
 
 dependencies = [
     "exchange_calendars",
-    "numpy<2",
+    "numpy",
     "pandas",
     "tzdata",
     "yahooquery",
@@ -98,4 +99,4 @@ write_to = "src/market_prices/_version.py"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -48,6 +48,8 @@ from .test_base_prices import (
 # ...sessions that yahoo temporarily fails to return prices for if (seemingly)
 # send a high frequency of requests for prices from the same IP address.
 _flakylist = (
+    pd.Timestamp("2024-05-28"),
+    pd.Timestamp("2024-05-27"),
     pd.Timestamp("2024-01-21"),
     pd.Timestamp("2023-09-08"),
     pd.Timestamp("2023-09-01"),
@@ -430,8 +432,8 @@ class TestConstructor:
     @pytest.fixture(scope="class")
     def symbols(self) -> abc.Iterator[str]:
         yield (
-            "GOOG IT4500.MI ^IBEX ^FTMC 9988.HK GBPEUR=X GC=F BTC-GBP CL=F"
-            " ES=F ZB=F HG=F GEN.L QAN.AX CA.PA BAS.DE FER.MC SPY QQQ ARKQ"
+            "GOOG FTSEMIB.MI ^IBEX ^FTMC 9988.HK GBPEUR=X GC=F BTC-GBP CL=F"
+            " ES=F ZB=F HG=F GEN.L QAN.AX CA.PA BAS.DE FER.MC SPY QQQ ARKG"
         )
 
     @pytest.fixture(scope="class")
@@ -444,7 +446,7 @@ class TestConstructor:
             "CA.PA": "XPAR",
             "BAS.DE": "XFRA",
             "FER.MC": "XMAD",
-            "IT4500.MI": "XMIL",
+            "FTSEMIB.MI": "XMIL",
             "^IBEX": "XMAD",
             "^FTMC": "XLON",
             "GBPEUR=X": "24/5",
@@ -456,7 +458,7 @@ class TestConstructor:
             "HG=F": "CMES",
             "SPY": "XNYS",  # ETF, yahoo exchange name is 'NYSEArca'
             "QQQ": "XNYS",  # ETF, yahoo exchange name is 'NasdaqGM'
-            "ARKQ": "XNYS",  # ETF, yahoo exchange name is 'BATS'
+            "ARKG": "XNYS",  # ETF, yahoo exchange name is 'BATS'
         }
 
     @pytest.fixture(scope="class")
@@ -469,7 +471,7 @@ class TestConstructor:
             "CA.PA": 15,
             "BAS.DE": 15,
             "FER.MC": 15,
-            "IT4500.MI": 15,
+            "FTSEMIB.MI": 15,
             "^IBEX": 15,
             "^FTMC": 15,
             "GBPEUR=X": 0,
@@ -481,7 +483,7 @@ class TestConstructor:
             "HG=F": 10,
             "SPY": 0,
             "QQQ": 0,
-            "ARKQ": 0,
+            "ARKG": 0,
         }
 
     def test_invalid_symbol(self, symbols):
@@ -554,7 +556,7 @@ class TestConstructor:
         repeated call (see 'Tests for `PricesYahoo`'
         section of docs/developers/testing).
         """
-        symbol, cal_name = "MSFT", "XNYS"
+        symbol, cal_name = "AZN.L", "XLON"
         prices = m.PricesYahoo(symbol, calendars=cal_name, delays=0)
         prices_adj = m.PricesYahoo(symbol, calendars=cal_name, delays=0, adj_close=True)
 


### PR DESCRIPTION
Updates dependencies, including bumping numpy to 2.0.

Also bumps upper supported python version to 3.12.