### PR TITLE
Update deps / Bump upper supported Python version to 3.12

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.11"]
+        os: [ubuntu-latest, macos-13, windows-latest]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -6,15 +6,15 @@
 #
 beautifulsoup4==4.12.3
     # via yahooquery
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-idna==3.6
+idna==3.7
     # via requests
 korean-lunar-calendar==0.3.1
     # via exchange-calendars
@@ -25,18 +25,18 @@ numpy==1.26.4
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pyluach==2.2.0
     # via exchange-calendars
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -48,14 +48,14 @@ soupsieve==2.5
     # via beautifulsoup4
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
 tzdata==2024.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -8,11 +8,11 @@ attrs==23.2.0
     # via hypothesis
 beautifulsoup4==4.12.3
     # via yahooquery
-black==24.2.0
+black==24.4.2
     # via market-prices (pyproject.toml)
 blosc2==2.5.1
     # via tables
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -23,21 +23,21 @@ colorama==0.4.6
     #   click
     #   pytest
     #   tqdm
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-flake8==7.0.0
+flake8==7.1.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.98.8
+hypothesis==6.104.0
     # via market-prices (pyproject.toml)
-idna==3.6
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -47,13 +47,13 @@ lxml==4.9.4
     # via yahooquery
 mccabe==0.7.0
     # via flake8
-msgpack==1.0.7
+msgpack==1.0.8
     # via blosc2
 mypy-extensions==1.0.0
     # via black
 ndindex==1.8
     # via blosc2
-numexpr==2.9.0
+numexpr==2.10.1
     # via tables
 numpy==1.26.4
     # via
@@ -63,27 +63,27 @@ numpy==1.26.4
     #   numexpr
     #   pandas
     #   tables
-packaging==23.2
+packaging==24.1
     # via
     #   black
     #   pytest
     #   tables
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
 pathspec==0.12.1
     # via black
-platformdirs==4.2.0
+platformdirs==4.2.2
     # via black
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
@@ -91,17 +91,17 @@ pyflakes==3.2.0
     # via flake8
 pyluach==2.2.0
     # via exchange-calendars
-pytest==8.0.1
+pytest==8.2.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -123,16 +123,16 @@ tomli==2.0.1
     #   pytest
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black
 tzdata==2024.1
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-astroid==3.0.3
+astroid==3.2.2
     # via pylint
 attrs==23.2.0
     # via hypothesis
 beautifulsoup4==4.12.3
     # via yahooquery
-black==24.2.0
+black==24.4.2
     # via market-prices (pyproject.toml)
 blosc2==2.5.1
     # via tables
-build==1.0.3
+build==1.2.1
     # via pip-tools
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -37,27 +37,27 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.5.3
+exchange-calendars==4.5.5
     # via market-prices (pyproject.toml)
-filelock==3.13.1
+filelock==3.15.4
     # via virtualenv
-flake8==7.0.0
+flake8==7.1.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.98.8
+hypothesis==6.104.0
     # via market-prices (pyproject.toml)
-identify==2.5.35
+identify==2.5.36
     # via pre-commit
-idna==3.6
+idna==3.7
     # via requests
-importlib-metadata==7.0.1
+importlib-metadata==7.2.1
     # via build
 iniconfig==2.0.0
     # via pytest
@@ -71,9 +71,9 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-msgpack==1.0.7
+msgpack==1.0.8
     # via blosc2
-mypy==1.8.0
+mypy==1.10.1
     # via market-prices (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -82,9 +82,9 @@ mypy-extensions==1.0.0
     #   mypy
 ndindex==1.8
     # via blosc2
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pre-commit
-numexpr==2.9.0
+numexpr==2.10.1
     # via tables
 numpy==1.26.4
     # via
@@ -95,63 +95,63 @@ numpy==1.26.4
     #   pandas
     #   pandas-stubs
     #   tables
-packaging==23.2
+packaging==24.1
     # via
     #   black
     #   build
     #   pytest
     #   tables
-pandas==2.2.0
+pandas==2.2.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==2.2.0.240218
+pandas-stubs==2.2.2.240603
     # via market-prices (pyproject.toml)
 pathspec==0.12.1
     # via black
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via market-prices (pyproject.toml)
-platformdirs==4.2.0
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-pre-commit==3.6.2
+pre-commit==3.7.1
     # via market-prices (pyproject.toml)
 py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.2.0
     # via flake8
-pylint==3.0.3
+pylint==3.2.3
     # via market-prices (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pytest==8.0.1
+pytest==8.2.2
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via pre-commit
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   yahooquery
@@ -174,17 +174,16 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pylint
-    #   pyproject-hooks
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.5
     # via pylint
 toolz==0.12.1
     # via exchange-calendars
-tqdm==4.66.2
+tqdm==4.66.4
     # via yahooquery
-types-pytz==2024.1.0.20240203
+types-pytz==2024.1.0.20240417
     # via pandas-stubs
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   astroid
     #   black
@@ -195,17 +194,17 @@ tzdata==2024.1
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)
-virtualenv==20.25.0
+virtualenv==20.26.3
     # via pre-commit
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
 yahooquery==2.3.7
     # via market-prices (pyproject.toml)
-zipp==3.17.0
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Education",
     "Topic :: Office/Business :: Financial",
@@ -98,4 +99,4 @@ write_to = "src/market_prices/_version.py"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312']

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -1811,7 +1811,7 @@ class PricesBase(metaclass=abc.ABCMeta):
             indices_aligned = self._indices_aligned[bi]
             for session, start, end in zip(sessions, session_opens, session_opens_next):
                 if not indices_aligned[session]:
-                    status[session] = np.NaN
+                    status[session] = np.nan
                     continue
                 bv = (all_in_left_nanos >= start.value) & (
                     all_in_right_nanos <= end.value
@@ -4649,7 +4649,7 @@ class PricesBase(metaclass=abc.ABCMeta):
             c = self.calendars[s]
             sdf = table[s].dropna()
             if sdf.empty:
-                d[s] = np.NaN
+                d[s] = np.nan
                 continue
             v = None
             if set_indice_to_now:

--- a/src/market_prices/prices/csv.py
+++ b/src/market_prices/prices/csv.py
@@ -404,7 +404,7 @@ class CsvIncongruentValuesError(CsvParsingError):
         super().__init__(path)
         self._msg = (
             "Parsed high and/or low values are incongrument with open"
-            f" and/or close values (threshold {self.thres*100}% of rows)."
+            f" and/or close values (threshold {self.thres * 100}% of rows)."
         )
 
 

--- a/src/market_prices/pt.py
+++ b/src/market_prices/pt.py
@@ -2415,7 +2415,7 @@ class PTMultipleSessions(_PTIntervalIndexNotIntraday):
         elif len(dates) == len(sessions) and (dates == sessions).all():
             return True
         else:
-            return np.NaN
+            return np.nan
 
     @functools.cache
     @parse
@@ -2625,7 +2625,7 @@ class PTDailyIntradayComposite(_PTIntervalIndexNotIntraday):
 
         For symbols where `date` represents a trading session, price will
         be as at session close. For all other symbols price is as at
-        previous close (or np.NaN if prices table starts later than the
+        previous close (or np.nan if prices table starts later than the
         previous close).
 
         Note: only available over range of index defined by sessions

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -94,18 +94,18 @@ def test_fill_reindexed():
         return m.fill_reindexed(df, cal, mock_bi, mock_symbol, "Yahoo")
 
     ohlcv = (
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [1.4, 1.8, 1.2, 1.6, 11],
         [2.4, 2.8, 2.2, 2.6, 22],
         [3.4, 3.8, 3.2, 3.6, 33],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [8.4, 8.8, 8.2, 8.6, 88],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [10.4, 10.8, 10.2, 10.6, 101],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
     )
     index = pd.DatetimeIndex(
         [
@@ -176,9 +176,9 @@ def test_fill_reindexed():
 
     ohlcv = (
         [0.4, 0.8, 0.2, 0.6, 1],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [2.4, 2.8, 2.2, 2.6, 22],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [4.4, 4.8, 4.2, 4.6, 44],
     )
 
@@ -203,9 +203,9 @@ def test_fill_reindexed():
         [0.4, 0.8, 0.2, 0.6, 1],
         [1.4, 1.8, 1.2, 1.6, 11],
         [2.4, 2.8, 2.2, 2.6, 22],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [6.4, 6.8, 6.2, 6.6, 66],
         [7.4, 7.8, 7.2, 7.6, 77],
         [8.4, 8.8, 8.2, 8.6, 88],
@@ -252,9 +252,9 @@ def test_fill_reindexed():
     # when prices for a first day are missing, verify raises warning and
     # fills back from next open.
     ohlcv = (
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [3.4, 3.8, 3.2, 3.6, 33],
         [4.4, 4.8, 4.2, 4.6, 44],
         [5.4, 5.8, 5.2, 5.6, 55],
@@ -291,24 +291,24 @@ def test_fill_reindexed():
     # verify raises warning and fills both ways (as noted above) for both xlon and
     # xasx (i.e. crossing UTC midnight, which involves different code path).
     ohlcv = (
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [1.4, 1.8, 1.2, 1.6, 11],
         [2.4, 2.8, 2.2, 2.6, 22],
         [3.4, 3.8, 3.2, 3.6, 33],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [6.4, 6.8, 6.2, 6.6, 66],
         [7.4, 7.8, 7.2, 7.6, 77],
         [8.4, 8.8, 8.2, 8.6, 88],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
     )
     index = pd.DatetimeIndex(
         [
@@ -419,15 +419,15 @@ def test_fill_reindexed_daily(one_min, monkeypatch):
         ]
     )
     ohlcv = (
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [1.4, 1.8, 1.2, 1.6, 11],
         [2.4, 2.8, 2.2, 2.6, 22],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [5.4, 5.8, 5.2, 5.6, 55],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [7.4, 7.8, 7.2, 7.6, 77],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
     )
 
     df = pd.DataFrame(ohlcv, index=index, columns=columns)
@@ -473,7 +473,7 @@ def test_fill_reindexed_daily(one_min, monkeypatch):
         warnings.warn(warnings_[0])
 
     missing_row = pd.DataFrame(
-        [[np.NaN] * 5], index=index[-1:], columns=columns, dtype="float64"
+        [[np.nan] * 5], index=index[-1:], columns=columns, dtype="float64"
     )
     expected = pd.concat([expected[:-1], missing_row])
     assert_frame_equal(rtrn, expected)
@@ -502,7 +502,7 @@ def test_fill_reindexed_daily(one_min, monkeypatch):
         [5.4, 5.8, 5.2, 5.6, 55],
         [6.4, 6.8, 6.2, 6.6, 66],
         [7.4, 7.8, 7.2, 7.6, 77],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
     )
     df = pd.DataFrame(ohlcv, index=index, columns=columns)
     rtrn, _ = f(df.copy(), xlon)
@@ -527,8 +527,8 @@ def test_fill_reindexed_daily(one_min, monkeypatch):
 
     # verify that missing prices before mindate are not filled and no warning raised
     ohlcv = (
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
-        [np.NaN, np.NaN, np.NaN, np.NaN, np.NaN],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
         [2.4, 2.8, 2.2, 2.6, 22],
         [3.4, 3.8, 3.2, 3.6, 33],
         [4.4, 4.8, 4.2, 4.6, 44],
@@ -2383,7 +2383,7 @@ class TestPricesBaseSetup:
         sessions = get_sessions(prices, bi)
         xasx_sessions, xhkg_sessions = get_calendars_sessions(prices, bi, [xasx, xhkg])
         # ...on a normal day sessions will conflict
-        expected = pd.Series(np.NaN, index=sessions, dtype="object")
+        expected = pd.Series(np.nan, index=sessions, dtype="object")
         # ...but if xasx open and xhkg closed, no partial indices
         expected[xasx_sessions.difference(xhkg_sessions)] = True
         # ...whilst if xhkg open and xasx closed, always partial indices

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -312,6 +312,11 @@ def test_volume_to_na(intraday_pt, intraday_pt_ss):
     assert_frame_equal(rtrn, df)
 
 
+# TODO Remove xfail when pandas >2.2 released
+# NB pd bug manifests in test, not package (manifests where evaluate
+# `expected_ooo.index = df[::12]`)
+# pandas issue ref is https://github.com/pandas-dev/pandas/issues/58604
+@pytest.mark.xfail(reason="Known pd issue with py3.12, should resolve with pd>2.2")
 def test_resample(intraday_pt):
     """Test `resample`.
 

--- a/tests/test_pt.py
+++ b/tests/test_pt.py
@@ -2142,6 +2142,11 @@ class TestDownsampleDaily:
             df.pt.downsample("3d", xnys),
         )
 
+    # TODO Remove xfail when pandas >2.2 released
+    # NB pd bug manifests in test, not package (manifests where takes a slice to
+    # evaluate 'subset').
+    # pandas issue ref is https://github.com/pandas-dev/pandas/issues/58604
+    @pytest.mark.xfail(reason="Known pd issue with py3.12, should resolve with pd>2.2")
     def test_monthly_freq(self, daily_pt, xnys, x247, one_day, symbols):
         """Verify "MS" and "QS" frequencies."""
         df = daily_pt

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -48,6 +48,8 @@ from .test_base_prices import (
 # ...sessions that yahoo temporarily fails to return prices for if (seemingly)
 # send a high frequency of requests for prices from the same IP address.
 _flakylist = (
+    pd.Timestamp("2024-05-28"),
+    pd.Timestamp("2024-05-27"),
     pd.Timestamp("2024-01-21"),
     pd.Timestamp("2023-09-08"),
     pd.Timestamp("2023-09-01"),
@@ -430,8 +432,8 @@ class TestConstructor:
     @pytest.fixture(scope="class")
     def symbols(self) -> abc.Iterator[str]:
         yield (
-            "GOOG IT4500.MI ^IBEX ^FTMC 9988.HK GBPEUR=X GC=F BTC-GBP CL=F"
-            " ES=F ZB=F HG=F GEN.L QAN.AX CA.PA BAS.DE FER.MC SPY QQQ ARKQ"
+            "GOOG FTSEMIB.MI ^IBEX ^FTMC 9988.HK GBPEUR=X GC=F BTC-GBP CL=F"
+            " ES=F ZB=F HG=F GEN.L QAN.AX CA.PA BAS.DE FER.MC SPY QQQ ARKG"
         )
 
     @pytest.fixture(scope="class")
@@ -444,7 +446,7 @@ class TestConstructor:
             "CA.PA": "XPAR",
             "BAS.DE": "XFRA",
             "FER.MC": "XMAD",
-            "IT4500.MI": "XMIL",
+            "FTSEMIB.MI": "XMIL",
             "^IBEX": "XMAD",
             "^FTMC": "XLON",
             "GBPEUR=X": "24/5",
@@ -456,7 +458,7 @@ class TestConstructor:
             "HG=F": "CMES",
             "SPY": "XNYS",  # ETF, yahoo exchange name is 'NYSEArca'
             "QQQ": "XNYS",  # ETF, yahoo exchange name is 'NasdaqGM'
-            "ARKQ": "XNYS",  # ETF, yahoo exchange name is 'BATS'
+            "ARKG": "XNYS",  # ETF, yahoo exchange name is 'BATS'
         }
 
     @pytest.fixture(scope="class")
@@ -469,7 +471,7 @@ class TestConstructor:
             "CA.PA": 15,
             "BAS.DE": 15,
             "FER.MC": 15,
-            "IT4500.MI": 15,
+            "FTSEMIB.MI": 15,
             "^IBEX": 15,
             "^FTMC": 15,
             "GBPEUR=X": 0,
@@ -481,7 +483,7 @@ class TestConstructor:
             "HG=F": 10,
             "SPY": 0,
             "QQQ": 0,
-            "ARKQ": 0,
+            "ARKG": 0,
         }
 
     def test_invalid_symbol(self, symbols):
@@ -554,7 +556,7 @@ class TestConstructor:
         repeated call (see 'Tests for `PricesYahoo`'
         section of docs/developers/testing).
         """
-        symbol, cal_name = "MSFT", "XNYS"
+        symbol, cal_name = "AZN.L", "XLON"
         prices = m.PricesYahoo(symbol, calendars=cal_name, delays=0)
         prices_adj = m.PricesYahoo(symbol, calendars=cal_name, delays=0, adj_close=True)
 


### PR DESCRIPTION
Updates dependencies, maintains numpy<2 given current pytables incompatibility.

Bumps upper supported python version to 3.12.

Moves mac runner for tests from 'latest' to 'macos-13' whilst awaiting release from pytables of wheels via pip for Mac M1.

Also updates some tests on `test_yahoo.py` to reflect changing characteristics of symbols used in live tests.