### PR TITLE
Dev and Fixes.

### DIFF
--- a/src/market_prices/prices/config/config_yahoo.py
+++ b/src/market_prices/prices/config/config_yahoo.py
@@ -59,6 +59,7 @@ EXCHANGE_TO_CALENDAR: dict = {
     "Oslo": "XOSL",
     "CCC": "24/7",
     "CCY": "24/5",
+    "Frankfurt": "XFRA",
 }
 
 DELAY_MAPPING: dict = {


### PR DESCRIPTION
Adds 'Frankfurt' exchange mapping for `PricesYahoo`.

Fixes bug that was forward filling most recent sessions for funds with sufficiently long price delays that prices for the most recent sessions were unavailable rather than missing.

Fixes flaky `test_daterange_duration_days_end_oolb_minute`.