### PR TITLE
Fix: Request live prices for delayed daily data

### DIFF
--- a/src/market_prices/data.py
+++ b/src/market_prices/data.py
@@ -663,7 +663,12 @@ class Data:
         """
         end = dr[1]
         if self.bi.is_one_day and end == helpers.now(self.bi):
-            end -= helpers.ONE_DAY
+            if self._delay is None:
+                margin = 1
+            else:
+                delay_in_days = self._delay.total_seconds() / (24 * 60 * 60)
+                margin = max(1, math.ceil(delay_in_days))
+            end -= helpers.ONE_DAY * margin
         elif self.bi.is_intraday:
             assert self._delay is not None
             # ten minutes to cover provider delays in publishing data.

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -1226,7 +1226,6 @@ class PricesBase(metaclass=abc.ABCMeta):
         d = {}
         max_delay = self.max_delay
         for bi in self.bis:
-            delay = max_delay if bi.is_intraday else None
             ll = self.base_limits[bi]
             if bi.is_daily:
                 if ll is not None:
@@ -1240,7 +1239,7 @@ class PricesBase(metaclass=abc.ABCMeta):
                 request=self._request_data,
                 cc=self.cc,
                 bi=bi,
-                delay=delay,
+                delay=max_delay,
                 left_limit=ll,
                 right_limit=self.base_limits_right[bi],
                 source_live=self.SOURCE_LIVE,


### PR DESCRIPTION
Previously would not re-request live indices for daily data with a delay > one day. This PR corrects `data.Data` to evaluate start date so that it accounts for any delay, thereby including 'live indices' in subsequent request to date source.

Adds test to check new behaviour.

Also fixes flaky test `test_daterange_duration_cal_end_minute_oolb`.