### PR TITLE
Provide for `start` and `end` kwargs to take a `datetime.date` / Update dependencies

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=etc/requirements.txt pyproject.toml
 #
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via yahooquery
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
 colorama==0.4.6
     # via tqdm
-exchange-calendars==4.7
+exchange-calendars==4.10
     # via market-prices (pyproject.toml)
 idna==3.10
     # via requests
@@ -20,7 +20,7 @@ korean-lunar-calendar==0.3.1
     # via exchange-calendars
 lxml==4.9.4
     # via yahooquery
-numpy==2.2.1
+numpy==2.2.4
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -34,7 +34,7 @@ pyluach==2.2.0
     # via exchange-calendars
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2024.2
+pytz==2025.2
     # via pandas
 requests==2.32.3
     # via
@@ -50,7 +50,9 @@ toolz==1.0.0
     # via exchange-calendars
 tqdm==4.67.1
     # via yahooquery
-tzdata==2024.2
+typing-extensions==4.13.1
+    # via beautifulsoup4
+tzdata==2025.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)

--- a/etc/requirements_dependabot/requirements_tests.txt
+++ b/etc/requirements_dependabot/requirements_tests.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --extra=tests --output-file=etc/requirements_dependabot/requirements_tests.txt pyproject.toml
 #
-attrs==24.3.0
+attrs==25.3.0
     # via hypothesis
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via yahooquery
-black==24.10.0
+black==25.1.0
     # via market-prices (pyproject.toml)
 blosc2==2.7.1
     # via tables
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -27,19 +27,19 @@ exceptiongroup==1.2.2
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.7
+exchange-calendars==4.10
     # via market-prices (pyproject.toml)
-flake8==7.1.1
+flake8==7.2.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.123.17
+hypothesis==6.128.2
     # via market-prices (pyproject.toml)
 idna==3.10
     # via requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 korean-lunar-calendar==0.3.1
     # via exchange-calendars
@@ -57,7 +57,7 @@ numexpr==2.10.2
     # via
     #   blosc2
     #   tables
-numpy==2.2.1
+numpy==2.2.4
     # via
     #   blosc2
     #   exchange-calendars
@@ -77,7 +77,7 @@ pandas==2.2.3
     #   yahooquery
 pathspec==0.12.1
     # via black
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via black
 pluggy==1.5.0
     # via pytest
@@ -85,15 +85,15 @@ py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.2.0
+pyflakes==3.3.2
     # via flake8
 pyluach==2.2.0
     # via exchange-calendars
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
@@ -101,7 +101,7 @@ pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2024.2
+pytz==2025.2
     # via pandas
 requests==2.32.3
     # via
@@ -127,11 +127,12 @@ toolz==1.0.0
     # via exchange-calendars
 tqdm==4.67.1
     # via yahooquery
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
+    #   beautifulsoup4
     #   black
     #   tables
-tzdata==2024.2
+tzdata==2025.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)

--- a/etc/requirements_dev.txt
+++ b/etc/requirements_dev.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --extra=dev --output-file=etc/requirements_dev.txt pyproject.toml
 #
-astroid==3.3.8
+astroid==3.3.9
     # via pylint
-attrs==24.3.0
+attrs==25.3.0
     # via hypothesis
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via yahooquery
-black==24.10.0
+black==25.1.0
     # via market-prices (pyproject.toml)
 blosc2==2.7.1
     # via tables
 build==1.2.2.post1
     # via pip-tools
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cfgv==3.4.0
     # via pre-commit
@@ -41,25 +41,25 @@ exceptiongroup==1.2.2
     # via
     #   hypothesis
     #   pytest
-exchange-calendars==4.7
+exchange-calendars==4.10
     # via market-prices (pyproject.toml)
-filelock==3.16.1
+filelock==3.18.0
     # via virtualenv
-flake8==7.1.1
+flake8==7.2.0
     # via
     #   flake8-docstrings
     #   market-prices (pyproject.toml)
 flake8-docstrings==1.7.0
     # via market-prices (pyproject.toml)
-hypothesis==6.123.17
+hypothesis==6.128.2
     # via market-prices (pyproject.toml)
-identify==2.6.5
+identify==2.6.9
     # via pre-commit
 idna==3.10
     # via requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-isort==5.13.2
+isort==6.0.1
     # via pylint
 korean-lunar-calendar==0.3.1
     # via exchange-calendars
@@ -71,7 +71,7 @@ mccabe==0.7.0
     #   pylint
 msgpack==1.1.0
     # via blosc2
-mypy==1.14.1
+mypy==1.15.0
     # via market-prices (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -86,7 +86,7 @@ numexpr==2.10.2
     # via
     #   blosc2
     #   tables
-numpy==2.2.1
+numpy==2.2.4
     # via
     #   blosc2
     #   exchange-calendars
@@ -106,32 +106,32 @@ pandas==2.2.3
     #   exchange-calendars
     #   market-prices (pyproject.toml)
     #   yahooquery
-pandas-stubs==2.2.3.241126
+pandas-stubs==2.2.3.250308
     # via market-prices (pyproject.toml)
 pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via market-prices (pyproject.toml)
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   black
     #   pylint
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==4.0.1
+pre-commit==4.2.0
     # via market-prices (pyproject.toml)
 py-cpuinfo==9.0.0
     # via
     #   blosc2
     #   tables
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.2.0
+pyflakes==3.3.2
     # via flake8
-pylint==3.3.3
+pylint==3.3.6
     # via market-prices (pyproject.toml)
 pyluach==2.2.0
     # via exchange-calendars
@@ -139,7 +139,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   market-prices (pyproject.toml)
     #   pytest-mock
@@ -147,7 +147,7 @@ pytest-mock==3.14.0
     # via market-prices (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2024.2
+pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via pre-commit
@@ -181,15 +181,16 @@ toolz==1.0.0
     # via exchange-calendars
 tqdm==4.67.1
     # via yahooquery
-types-pytz==2024.2.0.20241221
+types-pytz==2025.2.0.20250326
     # via pandas-stubs
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   astroid
+    #   beautifulsoup4
     #   black
     #   mypy
     #   tables
-tzdata==2024.2
+tzdata==2025.2
     # via
     #   exchange-calendars
     #   market-prices (pyproject.toml)
@@ -198,7 +199,7 @@ urllib3==2.3.0
     # via requests
 valimp==0.3
     # via market-prices (pyproject.toml)
-virtualenv==20.28.1
+virtualenv==20.30.0
     # via pre-commit
 wheel==0.45.1
     # via pip-tools

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -3303,11 +3303,11 @@ class PricesBase(metaclass=abc.ABCMeta):
             Parser(intervals.parse_interval, parse_none=False),
         ] = None,
         start: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
         ] = None,
         end: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
         ] = None,
         minutes: int = 0,
@@ -4295,7 +4295,7 @@ class PricesBase(metaclass=abc.ABCMeta):
     def session_prices(
         self,
         session: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
             Parser(parsing.verify_datetimestamp, parse_none=False),
         ] = None,
@@ -4306,7 +4306,8 @@ class PricesBase(metaclass=abc.ABCMeta):
         Parameters
         ----------
         session:
-            pd.Timestamp | str | datetime.datetime | int | float | None
+            pd.Timestamp | str | datetime.datetime | datetime.date
+            | int | float | None
         default: most recent available session
             Session to return prices for.
 
@@ -4387,7 +4388,7 @@ class PricesBase(metaclass=abc.ABCMeta):
     def close_at(
         self,
         date: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
             Parser(parsing.verify_datetimestamp, parse_none=False),
         ] = None,
@@ -4396,7 +4397,8 @@ class PricesBase(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        date : pd.Timestamp, str | datetime.datetime | int | float | None
+        date : pd.Timestamp, str | datetime.datetime | datetime.date
+        | int | float | None
         default: most recent date
             Date for which to return most recent end-of-day prices.
 
@@ -4865,11 +4867,11 @@ class PricesBase(metaclass=abc.ABCMeta):
     def price_range(
         self,
         start: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
         ] = None,
         end: Annotated[
-            pd.Timestamp | str | datetime.datetime | int | float | None,
+            pd.Timestamp | str | datetime.datetime | datetime.date | int | float | None,
             Coerce(pd.Timestamp),
         ] = None,
         minutes: int = 0,

--- a/src/market_prices/prices/csv.py
+++ b/src/market_prices/prices/csv.py
@@ -513,7 +513,7 @@ def compile_error_msgs(
 
 
 def _remove_unavailable_intervals_from_paths(
-    paths: dict[str, dict[TDInterval, Path]]
+    paths: dict[str, dict[TDInterval, Path]],
 ) -> tuple[
     dict[str, dict[TDInterval, Path]], list[PricesCsvIntervalUnavailableWarning]
 ]:
@@ -760,7 +760,7 @@ def parse_csvs(
 
 
 def _get_limits_from_parsed(
-    parsed: dict[TDInterval, dict[str, pd.DataFrame]]
+    parsed: dict[TDInterval, dict[str, pd.DataFrame]],
 ) -> tuple[dict[TDInterval, pd.Timestamp], dict[TDInterval, pd.Timestamp]]:
     """Get left and right limits by interval from parsed price data.
 

--- a/src/market_prices/utils/calendar_utils.py
+++ b/src/market_prices/utils/calendar_utils.py
@@ -1057,7 +1057,7 @@ class _CompositeNonTradingIndex:
         i = 0
 
         def add_to_dict(srs: pd.Series):
-            nonlocal d, i
+            nonlocal i
             d[i] = srs
             i += 1
 
@@ -1076,7 +1076,7 @@ class _CompositeNonTradingIndex:
         i = 0
 
         def add_to_dict(srs: pd.Series):
-            nonlocal d, i
+            nonlocal i
             d[i] = srs
 
             i += 1

--- a/src/market_prices/utils/pandas_utils.py
+++ b/src/market_prices/utils/pandas_utils.py
@@ -551,7 +551,7 @@ def index_is_normalized(
     index: Annotated[
         pd.DatetimeIndex | pd.IntervalIndex,
         Parser(verify_interval_datetime_index),
-    ]
+    ],
 ) -> bool:
     """Query if an index is normalized.
 

--- a/tests/test_base_prices.py
+++ b/tests/test_base_prices.py
@@ -2813,6 +2813,8 @@ class TestGet:
         """Test expected valid inputs for `start` and `end`.
 
         Also tests `tzin`.
+
+        NB passing as datetime.date tested in `test_start_end_parsing`.
         """
         # pylint: disable=undefined-loop-variable
         prices = prices_us_lon
@@ -2871,6 +2873,8 @@ class TestGet:
 
         Tests `start` and `end` being passed as dates and times that are
         aligned and unaligned with indices anchored on open.
+
+        Also tests that `start` and `end` can be passed as `datetime.date`.
         """
         prices = prices_us
         cal = prices.calendar_default
@@ -2880,8 +2884,13 @@ class TestGet:
         end = pd.Timestamp("2021-12-10")
         # verify getting daily data
         df = prices.get("1D", start, end)
-
         assertions_daily(df, prices, start, end)
+
+        # repeat for datetime.date to test that start and end can be passed as dates
+        start_ = datetime.date(2021, 12, 6)
+        end_ = datetime.date(2021, 12, 10)
+        df_ = prices.get("1D", start_, end_)
+        assert_frame_equal(df_, df)
 
         # verify passing `start` and `end` as dates that do not represent sessions
         df = prices.get("1D", start="2021-12-04", end="2021-12-11")

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -154,7 +154,7 @@ def test_remove_intervals_from_interval_invalid_input(
 def test_verify_interval_datetime_index():
     @parse
     def mock_func(
-        arg: Annotated[pd.IntervalIndex, Parser(m.verify_interval_datetime_index)]
+        arg: Annotated[pd.IntervalIndex, Parser(m.verify_interval_datetime_index)],
     ) -> pd.IntervalIndex:
         return arg
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -73,7 +73,7 @@ def test_verify_period_parameters():
         if minutes or hours:
             trading_kwargs.append(dict(minutes=minutes, hours=hours))
 
-    days_kwargs = [(dict(days=1))]
+    days_kwargs = [dict(days=1)]
 
     calendar_kwargs = []
     for weeks, months, years in itertools.product([0, 1], [0, 1], [0, 1]):


### PR DESCRIPTION
For functions of `base.PricesBase`, provides for passing as a `datetime.date` the `start` and `end` kwargs if they can define a
session.

Also updates dependencies.

Also some linting of otherwise untouched files, as required by latest versions of flake8 and black.