### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.12'
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
Pins python version to 3.12 to run new release action. Believe it might be using the latest version (3.13) that is causing the lxml dependency to fail to install.