### PR TITLE
Fix for failing yahoo tests using symbol QAN.AX

### DIFF
--- a/src/market_prices/prices/yahoo.py
+++ b/src/market_prices/prices/yahoo.py
@@ -720,8 +720,18 @@ class PricesYahoo(base.PricesBase):
         if not cal.is_trading_minute(last_indice):  # covers live indice as close
             return True
         if len(index) > 1:
+            minute_to_offset = index[-2]
+            # if clause is a fix to accommodate symbols that include a post close
+            # timestamp in the data (for example symbols using XASX calendar,
+            # including 'QAN.AX' used in testing).
+            if not cal.is_trading_minute(minute_to_offset):
+                minute_to_offset = cal.minute_to_trading_minute(
+                    minute_to_offset, direction="previous"
+                )
             # resolve here one way or the other
-            return cal.minute_offset(index[-2], interval.as_minutes) != last_indice
+            return (
+                cal.minute_offset(minute_to_offset, interval.as_minutes) != last_indice
+            )
         # longer alternative resolution
         session = cal.minute_to_session(last_indice)
         open_ = cal.session_open(session)

--- a/tests/test_yahoo.py
+++ b/tests/test_yahoo.py
@@ -913,7 +913,7 @@ class TestRequestDataIntraday:
         The Yahoo API appears to exhibit flaky behaviour when requesting
         prices from the supposed left limit (can return an an empty
         dataframe). This test serves to ensure `PricesYahoo` always returns
-        data when implicitely requesting prices from the left limit.
+        data when implicitly requesting prices from the left limit.
 
         Notes
         -----


### PR DESCRIPTION
Fixes the following tests that were failing on tested code fetching real-time 1min data for QAN.AX:
- test_request_from_left_limit
- test_prices_us_oz The yahoo data for symbols trading on XASX can now include a post-close 05:10 UTC print (close is 05:00). That this ts is not a trading minute was breaking `PricesYahoo._has_intraday_live_indice`. This fix simply offsets the ts (if not a trading minute) to the previous trading minute, i.e. in this case to the last trading minute of that session.