### PR TITLE
Avoid full-table copy in pt.operate when subsetting symbols

### DIFF
--- a/src/market_prices/pt.py
+++ b/src/market_prices/pt.py
@@ -959,15 +959,22 @@ class _PT(metaclass=abc.ABCMeta):
                 f" received as {exclude}.\n`include` received as {include}."
             )
 
-        prices = self.prices.copy()
+        # Subset to the requested symbols before copying so that the copy
+        # is no larger than necessary. Copying the full table first and only
+        # then subsetting makes a single-symbol selection cost the same as
+        # copying every symbol, which turns a per-symbol loop over the table
+        # into an O(num_symbols ** 2) operation.
         if include is not None and self.has_symbols:
-            prices = prices[helpers.symbols_to_list(include)]
+            prices = self.prices[helpers.symbols_to_list(include)].copy()
         elif exclude is not None and self.has_symbols:
             assert self.symbols is not None
             if set(exclude) == set(self.symbols):
                 raise ValueError("Cannot exclude all symbols.")
             exclude = helpers.symbols_to_list(exclude)
-            prices = prices[prices.columns.levels[0].difference(exclude)]
+            cols = self.prices.columns.levels[0].difference(exclude)
+            prices = self.prices[cols].copy()
+        else:
+            prices = self.prices.copy()
 
         if data_for_all or data_for_all_start:
             prices = prices.pt.data_for_all_start

--- a/src/market_prices/pt.py
+++ b/src/market_prices/pt.py
@@ -959,11 +959,6 @@ class _PT(metaclass=abc.ABCMeta):
                 f" received as {exclude}.\n`include` received as {include}."
             )
 
-        # Subset to the requested symbols before copying so that the copy
-        # is no larger than necessary. Copying the full table first and only
-        # then subsetting makes a single-symbol selection cost the same as
-        # copying every symbol, which turns a per-symbol loop over the table
-        # into an O(num_symbols ** 2) operation.
         if include is not None and self.has_symbols:
             prices = self.prices[helpers.symbols_to_list(include)].copy()
         elif exclude is not None and self.has_symbols:


### PR DESCRIPTION
(NB this offers a minor performance enhancement. What's implemented here didn't solve the bottleneck, but it is a better implementation.)

## Investigation

While profiling a per-symbol backtest loop (`for sym in tickers: df.pt.operate(include=sym, lose_single_symbol=True)`), `operate` showed a per-call cost that **grew with the number of symbols in the table** (≈2.0 ms at 50 symbols → ≈2.7 ms at 200), making the loop O(num_symbols²).

The cause: `operate` ran `prices = self.prices.copy()` — a deep copy of the **entire** multi-symbol table — and only *then* subset down to the requested `include`/`exclude` symbols. So selecting one symbol still paid the cost of copying every symbol.

## Fix

Subset to the requested symbols **before** copying, and copy only that subset. The `else` branch (no symbol selection) still copies the whole table, so the original is left unmodified in every case.

- Per-call cost is now **flat (~1.1 ms)** regardless of how many symbols the table holds.
- Functionally unchanged: verified `include`/`exclude` return the same columns/values as a full-frame selection, and the source table is not mutated.

## Test plan
- [x] `pytest tests/test_pt.py` (74 passed)
- [x] benchmark confirming flat per-call cost across 50/100/200/400 symbols
- [x] functional check: `include`, `exclude`, and original-frame-untouched
- [x] `ruff check` / `ruff format --check`

> Note: surfaced while investigating the `inv` backtest-loop slowdown (companion change in `inv` speeds up the per-symbol position evaluation).

https://claude.ai/code/session_01BMczt5nW8dHk2xytSXMEMU

---
Generated by Claude, fully reviewed
_Generated by [Claude Code](https://claude.ai/code/session_01BMczt5nW8dHk2xytSXMEMU)_