### PR TITLE
Speed up multi-symbol PricesYahoo instantiation

### DIFF
--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -1044,7 +1044,17 @@ class PricesBase(metaclass=abc.ABCMeta):
         kwargs = {"start": ll - pd.Timedelta(14, "D")} if ll is not None else {}
         for k, v in d.items():
             if not isinstance(v, xcals.ExchangeCalendar):
-                cal = xcals.get_calendar(v, side="left", **kwargs)
+                try:
+                    cal = xcals.get_calendar(v, side="left", **kwargs)
+                except ValueError:
+                    # `start` predates the earliest date from which this
+                    # calendar can be evaluated (e.g. another symbol with an
+                    # earlier first-trade date dragged the daily limit back
+                    # beyond this calendar's `bound_min`). Fall back to the
+                    # calendar's earliest supported start. Any resulting
+                    # shortfall against `ll` is flagged by the
+                    # `CalendarTooShortWarning` raised below.
+                    cal = xcals.get_calendar(v, side="left")
                 d[k] = cal
             elif v.side != "left":
                 msg = (

--- a/src/market_prices/utils/calendar_utils.py
+++ b/src/market_prices/utils/calendar_utils.py
@@ -202,8 +202,12 @@ def composite_schedule(calendars: abc.Sequence[xcals.ExchangeCalendar]) -> pd.Da
     index = pdutils.index_union(schedules)
     schedules = [sch.reindex(index) for sch in schedules]
     columns = pd.Index(["open", "close"])
-    opens = pd.DataFrame([sch[columns[0]] for sch in schedules]).min()
-    closes = pd.DataFrame([sch[columns[1]] for sch in schedules]).max()
+    # Reduce across calendars (axis=1, one column per calendar) rather than
+    # constructing a DataFrame with a column per session. The latter reduces
+    # over as many columns as there are sessions, which is orders of
+    # magnitude slower when the calendars span a long period.
+    opens = pd.concat([sch[columns[0]] for sch in schedules], axis=1).min(axis=1)
+    closes = pd.concat([sch[columns[1]] for sch in schedules], axis=1).max(axis=1)
     schedule = pd.concat([opens, closes], axis=1)
     schedule.columns = columns
     return schedule
@@ -363,12 +367,17 @@ class CompositeCalendar:
     @property
     def first_session(self) -> pd.Timestamp:
         """First composite session."""
-        return self.sessions[0]
+        # Evaluated directly from the underlying calendars rather than via
+        # `self.sessions` to avoid triggering construction of the full
+        # composite schedule, which can be costly when the calendars span a
+        # long period (and is unnecessary when only the bounds are required).
+        return max(c.first_session for c in self.calendars)
 
     @property
     def last_session(self) -> pd.Timestamp:
         """Last composite session."""
-        return self.sessions[-1]
+        # See comment to `first_session`.
+        return min(c.last_session for c in self.calendars)
 
     @property
     def first_minute(self) -> pd.Timestamp:


### PR DESCRIPTION
Instantiation of `mp.PricesYahoo(tickers)` becomes very slow with a high number of tickers, with the performance impairment possibly growing disproportionately with ticker count, and possibly some symbols having a greater affect that others.

## Investigation

Profiling `PricesYahoo.__init__` with the yahooquery network calls mocked out isolated the cost to calendar handling rather than networking:

- `PricesYahoo._set_daily_bi_limit` sets the daily base limit to the **global earliest first-trade date** across all symbols. A single old symbol (e.g. KO, first trade 1962) drags this limit — and therefore every calendar built in `PricesBase._set_calendars` — back ~60 years.
- The dominant hotspot (≈3s for a 1962→today span, called once during instantiation) was `composite_schedule` in `utils/calendar_utils.py`. It reduced open/close times across calendars by constructing `pd.DataFrame([sch["open"] for sch in schedules]).min()`, which builds a frame with **one column per session** and reduces over those (tens of thousands of) columns. Measured in isolation: 3.22s vs 0.006s for the equivalent per-row reduction — a ~500× difference, identical result.
- `CompositeCalendar.first_session` / `last_session` read `self.sessions[0]/[-1]`, forcing construction of the entire composite schedule just to obtain the bounds (which `__init__` queries).
- Separately, mixing an old symbol with a symbol on a younger-bounded calendar (e.g. `XTKS`, `bound_min` 1997) made instantiation **raise**, because the global daily limit was passed as `start` to a calendar that cannot be evaluated that far back.

## Changes

1. **`composite_schedule`** — reduce open/close across calendars with `pd.concat(..., axis=1).min(axis=1)` / `.max(axis=1)` instead of the transposed per-session-column reduction. Verified to produce identical schedules (full-DataFrame comparison across several calendar combinations, including `XTKS`/`XKRX`).
2. **`CompositeCalendar.first_session` / `last_session`** — evaluate directly as `max`/`min` of the underlying calendars' bounds, avoiding a full composite-schedule build when only the bounds are needed.
3. **`PricesBase._set_calendars`** — when the requested `start` (driven by the daily limit) predates a calendar's `bound_min`, fall back to the calendar's earliest supported start instead of raising. The pre-existing `CalendarTooShortWarning` already flags any shortfall against the limit.

## Measured impact

Instantiation time (yahooquery mocked, fresh process, sample mixing old US/EU symbols with a Tokyo symbol):

| symbols | before | after |
|--------:|-------:|------:|
| 6 | 2.80s | 0.71s |
| 8 | 4.50s | 1.41s |
| 10 | **crash** (`ValueError` on `XTKS`) | 2.03s |

All changes are behaviour-preserving for the schedule/bounds; the third change only affects cases that previously raised.

## Test plan

- [ ] `pytest tests/test_calendar_utils.py` (full suite needs network for answer-CSV fixtures; run in CI)
- [ ] `pytest tests/test_yahoo.py tests/test_base.py`
- [x] Offline equivalence check: new `composite_schedule` and `CompositeCalendar` bounds match the original implementation across multiple calendar combinations
- [x] `ruff check` / `ruff format --check` pass on changed files

https://claude.ai/code/session_018CDCHDRV5ikwiB6SSHYEcP

---
_Generated by [Claude Code](https://claude.ai/code/session_018CDCHDRV5ikwiB6SSHYEcP)_