### PR TITLE
Cache `yq.Ticker` properties for huge performance improvement with many symbols

### DIFF
--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -754,33 +754,78 @@ class PricesBase(metaclass=abc.ABCMeta):
                     value: int
                         Delay corresponding with symbol.
         """
+        last = datetime.datetime.now()
+
+        def tm() -> float:
+            now = datetime.datetime.now()
+            nonlocal last
+            diff = (now - last).total_seconds()
+            last = now
+            return diff
+
+        print(  # noqa: T201
+            "\nPricesBase: about to verify base intervals", tm()
+        )  # TODO: DEL DEBUG LINE
         self.verify_base_intervals()
         self._symbols = helpers.symbols_to_list(symbols)
         self._base_intervals: _BaseIntervalMeta
         self._base_limits: dict[BI, pd.Timedelta | pd.Timestamp | None]
+        print(  # noqa: T201
+            "PricesBase: about to verify base limits", tm()
+        )  # TODO: DEL DEBUG LINE
         self._verify_base_limits()
         self._base_limits_right: dict[BI, pd.Timestamp | None]
+        print(  # noqa: T201
+            "PricesBase: about to set and verify base_limits_right", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_base_limits_right()
         self._verify_base_limits_right()
         self._verify_lead_symbol(lead_symbol)
         self._calendars: dict[str, xcals.ExchangeCalendar]
+        print(  # noqa: T201
+            "PricesBase: about to set calendars", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_calendars(calendars)
         self._lead_calendar: xcals.ExchangeCalendar
+        print(  # noqa: T201
+            "PricesBase: about to set lead calendar", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_lead_calendar(lead_symbol)
         self._lead_symbol: str
         self._set_lead_symbol(lead_symbol)
         self._delays: dict[str, pd.Timedelta]
+        print(  # noqa: T201
+            "PricesBase: about to set delays", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_delays(delays)
+        print(  # noqa: T201
+            "PricesBase: about to create CompositeCalendar", tm()
+        )  # TODO: DEL DEBUG LINE
         self._cc = calutils.CompositeCalendar(self.calendars_unique)
         self._pdata: dict[BI, data.Data]
+        print(  # noqa: T201
+            "PricesBase: about to set pdata", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_pdata()
         self._trading_indexes_: dict[BI, pd.IntervalIndex]
+        print(  # noqa: T201
+            "PricesBase: about to set trading_indexes", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_trading_indexes()
         self._indices_aligned_: dict[BI, pd.Series]
+        print(  # noqa: T201
+            "PricesBase: about to set indices_aligned", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_indices_aligned()
         self._indexes_status_: dict[BI, pd.Series]
+        print(  # noqa: T201
+            "PricesBase: about to set indexes_status", tm()
+        )  # TODO: DEL DEBUG LINE
         self._set_indexes_status()
         self._gpp: PricesBase.GetPricesParams | None = None
+        print(  # noqa: T201
+            "PricesBase: exiting construction", tm()
+        )  # TODO: DEL DEBUG LINE
 
     @property
     def symbols(self) -> list[str]:

--- a/src/market_prices/prices/base.py
+++ b/src/market_prices/prices/base.py
@@ -754,78 +754,33 @@ class PricesBase(metaclass=abc.ABCMeta):
                     value: int
                         Delay corresponding with symbol.
         """
-        last = datetime.datetime.now()
-
-        def tm() -> float:
-            now = datetime.datetime.now()
-            nonlocal last
-            diff = (now - last).total_seconds()
-            last = now
-            return diff
-
-        print(  # noqa: T201
-            "\nPricesBase: about to verify base intervals", tm()
-        )  # TODO: DEL DEBUG LINE
         self.verify_base_intervals()
         self._symbols = helpers.symbols_to_list(symbols)
         self._base_intervals: _BaseIntervalMeta
         self._base_limits: dict[BI, pd.Timedelta | pd.Timestamp | None]
-        print(  # noqa: T201
-            "PricesBase: about to verify base limits", tm()
-        )  # TODO: DEL DEBUG LINE
         self._verify_base_limits()
         self._base_limits_right: dict[BI, pd.Timestamp | None]
-        print(  # noqa: T201
-            "PricesBase: about to set and verify base_limits_right", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_base_limits_right()
         self._verify_base_limits_right()
         self._verify_lead_symbol(lead_symbol)
         self._calendars: dict[str, xcals.ExchangeCalendar]
-        print(  # noqa: T201
-            "PricesBase: about to set calendars", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_calendars(calendars)
         self._lead_calendar: xcals.ExchangeCalendar
-        print(  # noqa: T201
-            "PricesBase: about to set lead calendar", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_lead_calendar(lead_symbol)
         self._lead_symbol: str
         self._set_lead_symbol(lead_symbol)
         self._delays: dict[str, pd.Timedelta]
-        print(  # noqa: T201
-            "PricesBase: about to set delays", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_delays(delays)
-        print(  # noqa: T201
-            "PricesBase: about to create CompositeCalendar", tm()
-        )  # TODO: DEL DEBUG LINE
         self._cc = calutils.CompositeCalendar(self.calendars_unique)
         self._pdata: dict[BI, data.Data]
-        print(  # noqa: T201
-            "PricesBase: about to set pdata", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_pdata()
         self._trading_indexes_: dict[BI, pd.IntervalIndex]
-        print(  # noqa: T201
-            "PricesBase: about to set trading_indexes", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_trading_indexes()
         self._indices_aligned_: dict[BI, pd.Series]
-        print(  # noqa: T201
-            "PricesBase: about to set indices_aligned", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_indices_aligned()
         self._indexes_status_: dict[BI, pd.Series]
-        print(  # noqa: T201
-            "PricesBase: about to set indexes_status", tm()
-        )  # TODO: DEL DEBUG LINE
         self._set_indexes_status()
         self._gpp: PricesBase.GetPricesParams | None = None
-        print(  # noqa: T201
-            "PricesBase: exiting construction", tm()
-        )  # TODO: DEL DEBUG LINE
 
     @property
     def symbols(self) -> list[str]:

--- a/src/market_prices/prices/yahoo.py
+++ b/src/market_prices/prices/yahoo.py
@@ -380,12 +380,35 @@ class PricesYahoo(base.PricesBase):
     # Methods called via constructor
 
     @functools.cached_property
+    def _ticker_price(self) -> dict[str, str]:
+        """`Ticker.price` property.
+
+        Notes
+        -----
+        Cached as otherwise data fetched from yahoo on every call to
+        property `_ticker.price`.
+        """
+        return self._ticker.price
+
+    @functools.cached_property
+    def _ticker_quote_type(self) -> dict[str, str]:
+        """`Ticker.quote_type` property.
+
+        Notes
+        -----
+        Cached as otherwise data fetched from yahoo on every call to
+        property `_ticker.quote_type`.
+        """
+        return self._ticker.quote_type
+
+    @functools.cached_property
     def _yahoo_exchange_name(self) -> dict[str, str]:
-        if self._ticker.price == ERROR404:
+        price_data = self._ticker_price
+        if price_data == ERROR404:
             raise YahooAPIError("price")
         d = {}
         for s in self._ticker.symbols:
-            d[s] = self._ticker.price[s]["exchangeName"]
+            d[s] = price_data[s]["exchangeName"]
             # the quotes endpoint's fullExchangeName was more comprehensive
             # although endpoint went behind a cookie request on 23/04/20
             # and again on 23/05/25.
@@ -454,7 +477,7 @@ class PricesYahoo(base.PricesBase):
     def _real_time(self) -> dict[str, bool]:
         """Return dictionary indicating if symbols have real time pricing."""
         d = {}
-        price = self._ticker.price
+        price = self._ticker_price
         if price == ERROR404:
             raise YahooAPIError("price")
         for s in self._ticker.symbols:
@@ -517,7 +540,7 @@ class PricesYahoo(base.PricesBase):
 
     @functools.cached_property
     def _first_trade_dates(self) -> dict[str, pd.Timestamp | None]:
-        quote_type = self._ticker.quote_type
+        quote_type = self._ticker_quote_type
         first_trade_dates: dict[str, pd.Timestamp | None] = {}
         for s in self._ticker.symbols:
             if quote_type == ERROR404:


### PR DESCRIPTION
Caches `yahooquery.Ticker` properties `Ticker.price` and `Ticker.quote_type`. These properties fetch data from Yahoo on every call although for the fields accessed by `PricesYahoo` there's no advantage in refreshing the data - only static fields are read.

Caching the return provides for performance improvement when calendars and delays are not passed to the constructor (when would otherwise call make two calls for the same data). Moreover, revises the `_yahoo_exchange_name` method which was previously fetching the same data for all symbols once per symbol! This was leading to increasingly horrendous performance with increasing number of symbols (and making the class pretty much unusable for >10 symbols if `calendars` and `delays` were not being explicitly passed). In this respect the PR could be considered as much a bug fix as an enhancement.